### PR TITLE
feat: add requiredOption for option metadata

### DIFF
--- a/.changeset/chatty-impalas-sin.md
+++ b/.changeset/chatty-impalas-sin.md
@@ -1,0 +1,5 @@
+---
+'nest-commander': minor
+---
+
+Adds in a new metadata option for the @Option() decorator to make the option required, just like a required argument

--- a/apps/docs/docs/api.md
+++ b/apps/docs/docs/api.md
@@ -28,6 +28,7 @@ This method decorator allows for users to pass in extra options for commands def
 | flags | `string` | true | The flags that should work for this option. Multiple flags can exist for a single option, so long as they are separated by a comma, space, or pipe character. Just like with arguments, `<>` for required, `[]` for optional. |
 | description | `string` | false | The description of the flags and option. Used with the `--help` output |
 | defaultValue | `string or boolean` | false | The default value, if any, for the option |
+| required | `boolean` | false | Make the option required like an argument and the command fail if the option is not provided |
 
 ### InquirerService
 

--- a/apps/docs/docs/features/commander.md
+++ b/apps/docs/docs/features/commander.md
@@ -78,6 +78,8 @@ For more details on everything that is possible with options, take a look at [`c
 
 :::
 
+You can also make an option completely required, like an argument, by setting `required: true` in the metadata for the option.
+
 ## The Full Command
 
 Let's say all we want to do is have our `run` command run the task in another shell, and that's it. If we take our above command we can see that it can be ran like so

--- a/packages/nest-commander/src/command-runner.interface.ts
+++ b/packages/nest-commander/src/command-runner.interface.ts
@@ -38,6 +38,7 @@ export interface OptionMetadata {
   flags: string;
   description?: string;
   defaultValue?: string | boolean;
+  required?: boolean;
 }
 
 export interface RunnerMeta {


### PR DESCRIPTION
This adds in some metadata for `@Option()` to make commander use `requiredOption` so that if the option is missing when the command is ran, it fails with an error message. Similar to a missing required argument. 

This commit also updates the implementation to no longer use the `description` methods to add argument descriptions, but maps them manually from the existing metadata to bring no breaking changes. Just making a mention in case things break. Closes #37 