### PR TITLE
feat: allows the ability to create subcommands

### DIFF
--- a/.changeset/pink-forks-smile.md
+++ b/.changeset/pink-forks-smile.md
@@ -1,0 +1,7 @@
+---
+'nest-commander': minor
+---
+
+Subcommands can now be created
+
+There's a new decorator, `@SubCommand()` for creating nested commands like `docker compose up`. There's also a new option on `@Command()` (`subCommands`) for setting up this sub command relationship.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
   
   auto-merge:
     needs: pr
-    if: contains(github.event.pull_request.user.login, 'dependabot') || container(github.event.pull_request.user.login, 'renovate')
+    if: contains(github.event.pull_request.user.login, 'dependabot') || contains(github.event.pull_request.user.login, 'renovate')
     runs-on: ubuntu-latest
     steps:
     - name: automerge

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
     - cron: '0 0 * * *'
 
 env:
-  NX_CLOUD_DISTRIBUTED_EXECUTION: ${{ !contains(github.event.pull_request.user.login, 'dependabot') }}
+  NX_CLOUD_DISTRIBUTED_EXECUTION: ${{ !contains(github.event.pull_request.user.login, 'dependabot') && !contains(github.event.pull_request.user.login, 'renovate') }}
   NX_CLOUD_AUTH_TOKEN: ${{ secrets.NX_CLOUD_TOKEN }}
 
 jobs:
@@ -97,7 +97,7 @@ jobs:
   
   auto-merge:
     needs: pr
-    if: contains(github.event.pull_request.user.login, 'dependabot')
+    if: contains(github.event.pull_request.user.login, 'dependabot') || container(github.event.pull_request.user.login, 'renovate')
     runs-on: ubuntu-latest
     steps:
     - name: automerge
@@ -109,7 +109,7 @@ jobs:
 
   agents:
     runs-on: ubuntu-latest
-    name: Agent 1
+    name: Nx Agent
     timeout-minutes: 60
     strategy:
       matrix:

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
 
 jobs:
-  docs-changed:
+  changes:
     runs-on: ubuntu-latest
     outputs:
       files: ${{ contains(steps.files.outputs.added_modified, '/apps/docs/') }}
@@ -19,12 +19,9 @@ jobs:
   docs-deploy:
     runs-on: ubuntu-latest
     needs:
-      - docs-changed
-    if: ${{ needs.docs-changed.outputs.files }}
+      - changes
+    if: ${{ needs.changes.outputs.files }}
     steps:
-      - name: Get All Changed Files
-        id: files
-        uses: jitterbit/get-changed-files@v1
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,9 @@ jobs:
         run: pnpm build
 
       - name: Modify Workspace File
+        # modify the current pnpm-workspace to point at `dist` instead of `packages`
         run: sed -e "s|'packages\/|'dist/|" pnpm-workspace.yaml > pnpm-new.yaml && mv pnpm-new.yaml pnpm-workspace.yaml
-      
-      - name: Print pnpm-workspace.yaml
-        run: cat pnpm-workspace.yaml
-      
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@master

--- a/apps/docs/docs/api.md
+++ b/apps/docs/docs/api.md
@@ -18,6 +18,13 @@ This class decorator is pretty much what everything else in this package relies 
 | description | `string` | false | The description of what the command does. This will be printed on the `--help` usage |
 | argsDescription | `Record<string, string>` | false | The description for each argument. It will be used on `--help` as well |
 | options | `CommandOptions` | false | Extra options to pass to the commander instance. Check [commander's types](https://github.com/tj/commander.js/blob/master/typings/index.d.ts#L713) for more information. |
+| subCommands | `Type<CommandRunner>` | false | Subcommands related to the parent command, e.g. `docker compose up` and `docker compose stop` |
+
+:::note
+
+The above information holds for `@SubCommand()` as well, though `default` under `options` has no effect
+
+:::
 
 #### @Option()
 

--- a/apps/docs/docs/features/commander.md
+++ b/apps/docs/docs/features/commander.md
@@ -84,6 +84,30 @@ You can also make an option completely required, like an argument, by setting `r
 
 By default, `commander` sets help to the `--help` or `-h` flag. If you need extra help added to the command, you can use the `@Help()` decorator on a class method that returns a string. The valid values for the `@Help()` decorator are `before`, `beforeAll`, `after` and `afterAll`, just like for commander's `addHelpText` method.
 
+## Sub Commands
+
+It may also be that you want to add subcommands to your command, similar to `docker compose up`. This is possible with the `@SubCommand()` decorator. Using this decorator, you can have your original implementation for the `@Command()` decorator, with arguments as normal, and you can have sub commands, as specific arguments that take in even more options. With our `run` example above, lets say we wanted to add a subcommand, `foo`. We'd make use of the `parents` option for the `run` command and reference the subcommand class, like so:
+
+```ts
+@Command({
+  name: 'run',
+  arguments: '<task>',
+  subcommands: [FooCommand]
+})
+export class RunCommand implements CommandRunner {}
+```
+
+Now we just make a subcommand with the same metadata options as the `@Command()` decorator
+
+```ts
+@SubCommand({ name: 'foo', arguments: '[phooey]' })
+export class FooCommand implements CommandRunner {
+  // command runner implementation
+}
+```
+
+and now nest-commander will set up the command so you can call `crun run foo hello!` and the `FooCommand#run` method will be ran instead of `RunCommand#run`. You can also chain commands as deep as you want, by adding `subCommands` to the subcommand's metadata.
+
 ## The Full Command
 
 Let's say all we want to do is have our `run` command run the task in another shell, and that's it. If we take our above command we can see that it can be ran like so

--- a/integration/sub-commands/src/bottom.command.ts
+++ b/integration/sub-commands/src/bottom.command.ts
@@ -1,0 +1,12 @@
+import { CommandRunner, SubCommand } from 'nest-commander';
+
+import { LogService } from '../../common/log.service';
+
+@SubCommand({ name: 'bottom' })
+export class BottomCommand implements CommandRunner {
+  constructor(private readonly log: LogService) {}
+
+  async run() {
+    this.log.log('top mid-1 bottom command');
+  }
+}

--- a/integration/sub-commands/src/mid-1.command.ts
+++ b/integration/sub-commands/src/mid-1.command.ts
@@ -3,7 +3,7 @@ import { CommandRunner, SubCommand } from 'nest-commander';
 import { LogService } from '../../common/log.service';
 import { BottomCommand } from './bottom.command';
 
-@SubCommand({ name: 'mid-1', parent: [BottomCommand] })
+@SubCommand({ name: 'mid-1', subCommands: [BottomCommand] })
 export class Mid1Command implements CommandRunner {
   constructor(private readonly log: LogService) {}
 

--- a/integration/sub-commands/src/mid-1.command.ts
+++ b/integration/sub-commands/src/mid-1.command.ts
@@ -1,0 +1,13 @@
+import { CommandRunner, SubCommand } from 'nest-commander';
+
+import { LogService } from '../../common/log.service';
+import { BottomCommand } from './bottom.command';
+
+@SubCommand({ name: 'mid-1', parent: [BottomCommand] })
+export class Mid1Command implements CommandRunner {
+  constructor(private readonly log: LogService) {}
+
+  async run() {
+    this.log.log('top mid-1 command');
+  }
+}

--- a/integration/sub-commands/src/mid-2.command.ts
+++ b/integration/sub-commands/src/mid-2.command.ts
@@ -1,0 +1,12 @@
+import { CommandRunner, SubCommand } from 'nest-commander';
+
+import { LogService } from '../../common/log.service';
+
+@SubCommand({ name: 'mid-2' })
+export class Mid2Command implements CommandRunner {
+  constructor(private readonly log: LogService) {}
+
+  async run() {
+    this.log.log('top mid-2 command');
+  }
+}

--- a/integration/sub-commands/src/nested.module.ts
+++ b/integration/sub-commands/src/nested.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+
+import { LogService } from '../../common/log.service';
+import { BottomCommand } from './bottom.command';
+import { Mid1Command } from './mid-1.command';
+import { Mid2Command } from './mid-2.command';
+import { TopCommand } from './top.command';
+
+@Module({
+  providers: [LogService, TopCommand, Mid1Command, Mid2Command, BottomCommand],
+})
+export class NestedModule {}

--- a/integration/sub-commands/src/top.command.ts
+++ b/integration/sub-commands/src/top.command.ts
@@ -1,0 +1,14 @@
+import { Command, CommandRunner } from 'nest-commander';
+
+import { LogService } from '../../common/log.service';
+import { Mid1Command } from './mid-1.command';
+import { Mid2Command } from './mid-2.command';
+
+@Command({ name: 'top', parent: [Mid1Command, Mid2Command] })
+export class TopCommand implements CommandRunner {
+  constructor(private readonly log: LogService) {}
+
+  async run() {
+    this.log.log('top command');
+  }
+}

--- a/integration/sub-commands/src/top.command.ts
+++ b/integration/sub-commands/src/top.command.ts
@@ -4,11 +4,12 @@ import { LogService } from '../../common/log.service';
 import { Mid1Command } from './mid-1.command';
 import { Mid2Command } from './mid-2.command';
 
-@Command({ name: 'top', parent: [Mid1Command, Mid2Command] })
+@Command({ name: 'top', arguments: '[name]', subCommands: [Mid1Command, Mid2Command] })
 export class TopCommand implements CommandRunner {
   constructor(private readonly log: LogService) {}
 
-  async run() {
+  async run(inputs: string[]) {
     this.log.log('top command');
+    this.log.log(inputs);
   }
 }

--- a/integration/sub-commands/test/sub-commands.spec.ts
+++ b/integration/sub-commands/test/sub-commands.spec.ts
@@ -6,6 +6,8 @@ import { NestedModule } from '../src/nested.module';
 describe('Sub Commands', () => {
   let commandModule: TestingModule;
   const logMock: jest.Mock = jest.fn();
+  const exitMock: jest.Mock = jest.fn();
+  const trueExit = process.exit;
 
   beforeAll(async () => {
     commandModule = await CommandTestFactory.createTestingCommand({
@@ -16,20 +18,26 @@ describe('Sub Commands', () => {
         log: logMock,
       })
       .compile();
+    process.exit = exitMock as never;
   });
 
   afterEach(() => {
     logMock.mockReset();
+    exitMock.mockReset();
+  });
+
+  afterAll(() => {
+    process.exit = trueExit;
   });
   it.each`
     command
-    ${'top'}
-    ${'top mid-1'}
-    ${'top mid-1 bottom'}
-    ${'top mid-2'}
-  `('should run the $command command', async ({ command }: { command: string }) => {
-    await CommandTestFactory.run(commandModule, [command]);
-    expect(logMock).toBeCalledWith(`${command} command`);
+    ${['top']}
+    ${['top', 'mid-1']}
+    ${['top', 'mid-1', 'bottom']}
+    ${['top', 'mid-2']}
+  `('should run the $command command', async ({ command }: { command: string[] }) => {
+    await CommandTestFactory.run(commandModule, [...command]);
+    expect(logMock).toBeCalledWith(`${command.join(' ')} command`);
   });
   it.each`
     command
@@ -39,5 +47,6 @@ describe('Sub Commands', () => {
   `('should  error on $command', async ({ command }: { command: string }) => {
     await expect(CommandTestFactory.run(commandModule, [command])).resolves.toBeUndefined();
     expect(logMock).toBeCalledTimes(0);
+    expect(exitMock).toBeCalledWith(1);
   });
 });

--- a/integration/sub-commands/test/sub-commands.spec.ts
+++ b/integration/sub-commands/test/sub-commands.spec.ts
@@ -1,0 +1,43 @@
+import { TestingModule } from '@nestjs/testing';
+import { CommandTestFactory } from 'nest-commander-testing';
+import { LogService } from '../../common/log.service';
+import { NestedModule } from '../src/nested.module';
+
+describe('Sub Commands', () => {
+  let commandModule: TestingModule;
+  const logMock: jest.Mock = jest.fn();
+
+  beforeAll(async () => {
+    commandModule = await CommandTestFactory.createTestingCommand({
+      imports: [NestedModule],
+    })
+      .overrideProvider(LogService)
+      .useValue({
+        log: logMock,
+      })
+      .compile();
+  });
+
+  afterEach(() => {
+    logMock.mockReset();
+  });
+  it.each`
+    command
+    ${'top'}
+    ${'top mid-1'}
+    ${'top mid-1 bottom'}
+    ${'top mid-2'}
+  `('should run the $command command', async ({ command }: { command: string }) => {
+    await CommandTestFactory.run(commandModule, [command]);
+    expect(logMock).toBeCalledWith(`${command} command`);
+  });
+  it.each`
+    command
+    ${'mid-1'}
+    ${'mid-2'}
+    ${'bottom'}
+  `('should  error on $command', async ({ command }: { command: string }) => {
+    await expect(CommandTestFactory.run(commandModule, [command])).resolves.toBeUndefined();
+    expect(logMock).toBeCalledTimes(0);
+  });
+});

--- a/integration/sub-commands/test/sub-commands.spec.ts
+++ b/integration/sub-commands/test/sub-commands.spec.ts
@@ -39,6 +39,12 @@ describe('Sub Commands', () => {
     await CommandTestFactory.run(commandModule, [...command]);
     expect(logMock).toBeCalledWith(`${command.join(' ')} command`);
   });
+  it('should still be able to pass arguments', async () => {
+    await CommandTestFactory.run(commandModule, ['top', 'hello!']);
+    expect(logMock).toBeCalledTimes(2);
+    expect(logMock).toHaveBeenNthCalledWith(1, 'top command');
+    expect(logMock).toHaveBeenNthCalledWith(2, ['hello!']);
+  });
   it.each`
     command
     ${'mid-1'}

--- a/packages/nest-commander/src/command-runner.interface.ts
+++ b/packages/nest-commander/src/command-runner.interface.ts
@@ -33,7 +33,7 @@ export interface CommandMetadata {
   description?: string;
   argsDescription?: Record<string, string>;
   options?: CommandOptions;
-  parent?: Array<Type<CommandRunner>>;
+  subCommands?: Array<Type<CommandRunner>>;
 }
 
 export interface OptionMetadata {

--- a/packages/nest-commander/src/command-runner.interface.ts
+++ b/packages/nest-commander/src/command-runner.interface.ts
@@ -1,4 +1,5 @@
 import { DiscoveredMethodWithMeta } from '@golevelup/nestjs-discovery';
+import { Type } from '@nestjs/common';
 import { CommandOptions } from 'commander';
 import type {
   CheckboxQuestion,
@@ -32,6 +33,7 @@ export interface CommandMetadata {
   description?: string;
   argsDescription?: Record<string, string>;
   options?: CommandOptions;
+  parent?: Array<Type<CommandRunner>>;
 }
 
 export interface OptionMetadata {

--- a/packages/nest-commander/src/command-runner.service.ts
+++ b/packages/nest-commander/src/command-runner.service.ts
@@ -91,12 +91,12 @@ export class CommandRunnerService implements OnModuleInit {
     newCommand.action(() =>
       command.instance.run.call(command.instance, newCommand.args, newCommand.opts()),
     );
-    if (command.command.parent?.length) {
+    if (command.command.subCommands?.length) {
       this.subCommands ??= await this.discoveryService.providersWithMetaAtKey<CommandMetadata>(
         SubCommandMeta,
       );
       const subCommandsMetaForCommand = this.subCommands.filter((subMeta) =>
-        command.command.parent
+        command.command.subCommands
           ?.map((subCommand) => subCommand.name)
           .includes(subMeta.discoveredClass.name),
       );

--- a/packages/nest-commander/src/command.decorators.ts
+++ b/packages/nest-commander/src/command.decorators.ts
@@ -1,5 +1,4 @@
 import { Type } from '@nestjs/common';
-import { Question } from 'inquirer';
 import {
   CommandMetadata,
   CommandRunner,
@@ -17,12 +16,13 @@ import {
   OptionMeta,
   QuestionMeta,
   QuestionSetMeta,
+  SubCommandMeta,
   TransformMeta,
   ValidateMeta,
   WhenMeta,
 } from './constants';
 
-function applyMethodMetadata(options: any, metadataKey: string): MethodDecorator {
+const applyMethodMetadata = (options: any, metadataKey: string): MethodDecorator => {
   return (
     _target: Record<string, any>,
     _propertyKey: string | symbol,
@@ -31,56 +31,62 @@ function applyMethodMetadata(options: any, metadataKey: string): MethodDecorator
     Reflect.defineMetadata(metadataKey, options, descriptor.value);
     return descriptor;
   };
-}
+};
 
-function applyClassMetadata(options: any, metadataKey: string): ClassDecorator {
+const applyClassMetadata = (options: any, metadataKey: string): ClassDecorator => {
   return (target) => {
     Reflect.defineMetadata(metadataKey, options, target);
     return target;
   };
-}
-export function Command(
+};
+export const Command = (
   options: CommandMetadata,
-): <TFunction extends Type<CommandRunner>>(target: TFunction) => void | TFunction {
+): (<TFunction extends Type<CommandRunner>>(target: TFunction) => void | TFunction) => {
   return applyClassMetadata(options, CommandMeta);
-}
+};
 
-export function Option(options: OptionMetadata): MethodDecorator {
+export const SubCommand = (
+  options: CommandMetadata,
+): (<TFunction extends Type<CommandRunner>>(target: TFunction) => void | TFunction) => {
+  return applyClassMetadata(options, SubCommandMeta);
+};
+
+export const Option = (options: OptionMetadata): MethodDecorator => {
   return applyMethodMetadata(options, OptionMeta);
-}
+};
 
-export function QuestionSet(options: QuestionNameMetadata): ClassDecorator {
+export const QuestionSet = (options: QuestionNameMetadata): ClassDecorator => {
   return applyClassMetadata(options, QuestionSetMeta);
-}
+};
 
-export function Question(options: QuestionMetadata): MethodDecorator {
+export const Question = (options: QuestionMetadata): MethodDecorator => {
   return applyMethodMetadata(options, QuestionMeta);
-}
+};
 
-export function ValidateFor(options: QuestionNameMetadata): MethodDecorator {
+export const ValidateFor = (options: QuestionNameMetadata): MethodDecorator => {
   return applyMethodMetadata(options, ValidateMeta);
-}
+};
 
-export function TransformFor(options: QuestionNameMetadata): MethodDecorator {
+export const TransformFor = (options: QuestionNameMetadata): MethodDecorator => {
   return applyMethodMetadata(options, TransformMeta);
-}
+};
 
-export function WhenFor(options: QuestionNameMetadata): MethodDecorator {
+export const WhenFor = (options: QuestionNameMetadata): MethodDecorator => {
   return applyMethodMetadata(options, WhenMeta);
-}
+};
 
-export function MessageFor(options: QuestionNameMetadata): MethodDecorator {
+export const MessageFor = (options: QuestionNameMetadata): MethodDecorator => {
   return applyMethodMetadata(options, MessageMeta);
-}
+};
 
-export function ChoicesFor(options: QuestionNameMetadata): MethodDecorator {
+export const ChoicesFor = (options: QuestionNameMetadata): MethodDecorator => {
   return applyMethodMetadata(options, ChoicesMeta);
-}
+};
 
-export function DefaultFor(options: QuestionNameMetadata): MethodDecorator {
+export const DefaultFor = (options: QuestionNameMetadata): MethodDecorator => {
   return applyMethodMetadata(options, DefaultMeta);
-}
+};
 
-export function Help(options: HelpOptions): MethodDecorator {
+export const Help = (options: HelpOptions): MethodDecorator => {
   return applyMethodMetadata(options, HelpMeta);
-}
+};

--- a/packages/nest-commander/src/constants.ts
+++ b/packages/nest-commander/src/constants.ts
@@ -1,12 +1,13 @@
-function metaKeyBuilder(suffix: string): string {
+const metaKeyBuilder = (suffix: string): string => {
   return `CommandBuilder:${suffix}`;
-}
+};
 
-function questionMetaBuilder(suffix: string): string {
+const questionMetaBuilder = (suffix: string): string => {
   return metaKeyBuilder(`Question:${suffix}`);
-}
+};
 
 export const CommandMeta = metaKeyBuilder('Command:Meta');
+export const SubCommandMeta = metaKeyBuilder('Subcommand:Meta');
 export const OptionMeta = metaKeyBuilder('Option:Meta');
 export const QuestionSetMeta = metaKeyBuilder('QuestionSet:Meta');
 export const QuestionMeta = questionMetaBuilder('Meta');


### PR DESCRIPTION
This will allow devs to set up sub/nested commands, similar to those from `docker` like `docker compose up` or `docker compose down`. There's a bit of recursive work going on here, so it may get to the point that we want some of this info to be cached, but it's working for now. 

closes #44 