### PR TITLE
style: fix misspelled 'parse'; and minor improvements on docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,2 +1,7 @@
 ## To encourage contributors to use issue templates, we don't allow blank issues
 blank_issues_enabled: false
+
+contact_links:
+  - name: "\u2753 Our GitHub Discussions page"
+    url: "https://github.com/jmcdo29/nest-commander/discussions"
+    about: "Please ask and answer questions here!"

--- a/apps/docs/docs/api.md
+++ b/apps/docs/docs/api.md
@@ -53,6 +53,7 @@ An asynchronous command to allow for getting user input based on existing option
 
 ```typescript
 ask<T>(name: string, options: Partial<T> | undefined): Promise<T>
+// The following is just an alias for the above
 prompt<T>(name: string, options: Partial<T> | undefined): Promise<T>
 ```
 

--- a/apps/docs/docs/api.md
+++ b/apps/docs/docs/api.md
@@ -78,7 +78,7 @@ This method decorator allows for creating questions to ask the user. For informa
 
 | Property | Type | Required | Description |
 | --- | --- | --- | --- |
-| type | `input`, `number`, `confirm`, `list`, `rawlist`, `expand`, `checkbox`, `password`, or `editor` | true | The kind of question for inquirer to ask. Each question has slightly different options, so pay attention to the type |
+| type | `input`, `number`, `confirm`, `list`, `rawlist`, `expand`, `checkbox`, `password`, or `editor` | false | The kind of question for inquirer to ask. Each question has slightly different options, so pay attention to the type |
 | name | `string` | true | The name of the question's input. This is used when being passed back from the `InquirerService` and can be used with the `@*For()` decorators described below |
 | message | `string` | true\* | The question to ask |
 | default | `string`, `number`, `boolean`, `array` | false | The default value for the question's input |

--- a/apps/docs/docs/features/factory.md
+++ b/apps/docs/docs/features/factory.md
@@ -30,7 +30,7 @@ And just like that, the command is hooked up and will run. You can use `typescri
 
 ## Logging
 
-By default, the `CommandFactory` turns **off** the Nest logger, due to the noise that the Nest logs create on startup with all of the modules and dependencies being resolved. If you'd like to turn logging back on, simple pass a valid logger configuration to the `CommandFactory` as a second parameter.
+By default, the `CommandFactory` turns **off** the Nest logger, due to the noise that the Nest logs create on startup with all of the modules and dependencies being resolved. If you'd like to turn logging back on, simple pass a valid logger configuration to the `CommandFactory` as a second parameter (e.g.: `new Logger()` from `@nestjs/common`).
 
 ## Error Handling
 

--- a/apps/docs/docs/features/factory.md
+++ b/apps/docs/docs/features/factory.md
@@ -30,7 +30,7 @@ And just like that, the command is hooked up and will run. You can use `typescri
 
 ## Logging
 
-By default, the `CommandFactory` turns **off** the Nest logger, due to the noise that the Nest logs create on startup with all of the modules and dependencies being resolved. If you'd like to turn logging back on, simple pass a valid logger configuration to the `CommandFactory` as a second paramter.
+By default, the `CommandFactory` turns **off** the Nest logger, due to the noise that the Nest logs create on startup with all of the modules and dependencies being resolved. If you'd like to turn logging back on, simple pass a valid logger configuration to the `CommandFactory` as a second parameter.
 
 ## Error Handling
 

--- a/apps/docs/docs/features/inquirer.md
+++ b/apps/docs/docs/features/inquirer.md
@@ -16,7 +16,7 @@ export class TaskQuestions {
     message: 'What task would you like to execute?',
     name: 'task'
   })
-  paseTask(val: string) {
+  parseTask(val: string) {
     return val;
   }
 }

--- a/apps/docs/docs/features/plugins.md
+++ b/apps/docs/docs/features/plugins.md
@@ -7,15 +7,15 @@ As of version 2.3.0, you can build your CLI with the ability to read for extra p
 
 ## The Config File
 
-The config file, by default, can be any of the following:
+The config file, by default, can be _one_ of the following:
 
-- .nest-commanderrc
-- .nest-commanderrc.json
-- .nest-commanderrc.yaml
-- .nest-commanderc.yml
-- nest-commander.json
-- nest-commander.yaml
-- nest-commander.yml
+- `.nest-commanderrc`
+- `.nest-commanderrc.json`
+- `.nest-commanderrc.yaml`
+- `.nest-commanderc.yml`
+- `nest-commander.json`
+- `nest-commander.yaml`
+- `nest-commander.yml`
 
 If you'd lke to use a name other than `nest-commander`, you can pass the `cliName` option to the `CommandFactory` as well.
 

--- a/apps/docs/docs/schematics/usage.md
+++ b/apps/docs/docs/schematics/usage.md
@@ -5,19 +5,31 @@ sidebar_label: Usage
 
 :::info
 
-We'll show how to use the `nest-commander-schematics` with the `@nestjs/cli`, but it works with `@angular/cli` and `nx` as well, as all of them use Angular's schematics under the hood.
+We'll show how to use the `nest-commander-schematics` with [`@nestjs/cli`](https://www.npmjs.com/package/@nestjs/cli), but it works with `@angular/cli` and `nx` as well, as all of them use Angular's schematics under the hood.
 
 :::
 
 ## Generating Commands
 
-To generate a simple command you can use
+To generate a simple command you can use the `command` schematic:
 
-```shell
+```
 nest g -c nest-commander-schematics command
 ```
 
-, from there the wizard will ask what the name of the command is and if you would like to add questions. You can choose no or provide a question set name at this point. You can also use `--default=true` to automatically set the `isDefault` option. `spec`, `flat`, `path`, and `sourceRoot` are also available options.
+from there the wizard will ask what the name of the command is and if you would like to add questions. You can choose _no_ or provide a question set name at this point.
+
+The available options for this command are the following:
+
+```
+--name=<name>         Command name.
+--path=<name>         The path to create the service.
+--sourceRoot=<name>   NestJS service source root directory.
+--flat                Whether or not a directory is created. (default: fale)
+--spec                Whether or not a spec file is generated. (default: true)
+--default             Whether or not the command is the default command for the CLI. (default: false)
+--question=<name>     The name of the related question set.
+```
 
 ### Generating Commands with Questions
 
@@ -25,10 +37,20 @@ As mentioned above, you can use the `command` schematic and provide a question s
 
 ## Generating Questions
 
-You can also generate a question set using the schematic
+You can also generate a question set using the `question` schematic:
 
-```shell
+```
 nest g -c nest-commander-schematics question
 ```
 
-from there you can provide a name for the question set as mentioned by the wizard. `spec`, `flat`, `path`, and `sourceRoot` are also usable options.
+from there you can provide a name for the question set as mentioned by the wizard.
+
+The available options for this command are the following:
+
+```
+--name=<name>         Questions set name.
+--path=<name>         The path to create the service.
+--sourceRoot=<name>   NestJS service source root directory.
+--flat                Whether or not a directory is created. (default: fale)
+--spec                Whether or not a spec file is generated. (default: true)
+```

--- a/apps/docs/docs/testing/factory.md
+++ b/apps/docs/docs/testing/factory.md
@@ -33,6 +33,12 @@ describe('Task Command', () => {
 });
 ```
 
+:::tip
+
+`TestingModule` is imported from `@nestjs/testing` package.
+
+:::
+
 Aside from the Jest spies that we're using, you'll notice that we use the `CommandTestFactory` to set up a `TestingModule` and use it to run a test command. We pass the `run` command here to match our `@Command()` we already created, but because `run` is the default command, it can be omitted. Then we pass in our arguments as the next array value, and any flags would be array values after it. All of this gets passed on to the commander instance and is processed as usual.
 
 ## Mocking User Input

--- a/packages/nest-commander-schematics/src/question/files/__name@dasherize__.questions.ts.template
+++ b/packages/nest-commander-schematics/src/question/files/__name@dasherize__.questions.ts.template
@@ -5,7 +5,7 @@ export class <%= classify(name) %>Questions {
   @Question({
     name: 'default',
   })
-  praseDefault(str: string): string {
+  parseDefault(str: string): string {
     return str;
   }
 }


### PR DESCRIPTION
I've read the whole docs and template files. Didn't find any other typo.
