### PR TITLE
Minor fix on npm-scripts, and add `x-prompt` on every schematic

### DIFF
--- a/.changeset/rotten-candles-dress.md
+++ b/.changeset/rotten-candles-dress.md
@@ -1,0 +1,5 @@
+---
+'nest-commander-schematics': minor
+---
+
+Add prompt to every schematic option

--- a/packages/nest-commander-schematics/package.json
+++ b/packages/nest-commander-schematics/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "prebuild": "rm -rf dist",
     "build": "tsc -p tsconfig.build.json",
-    "postbuild": "scripts/postbuild",
+    "postbuild": "./tools/schematics-postbuild",
     "test": "jest"
   },
   "keywords": [

--- a/packages/nest-commander-schematics/src/command/schema.json
+++ b/packages/nest-commander-schematics/src/command/schema.json
@@ -3,6 +3,7 @@
     "name": {
       "type": "string",
       "minLength": 1,
+      "description": "Command name",
       "x-prompt": "What is the command name?"
     },
     "path": {
@@ -17,17 +18,20 @@
     "flat": {
       "type": "boolean",
       "default": false,
-      "description": "Flag to indicate if a directory is created."
+      "description": "Flag to indicate if a directory is created.",
+      "x-prompt": "Create a directory?"
     },
     "spec": {
       "type": "boolean",
       "default": true,
-      "description": "Specifies if a spec file is generated."
+      "description": "Specifies if a spec file is generated.",
+      "x-prompt": "Generate spec file as well?"
     },
     "default": {
       "type": "boolean",
       "default": false,
-      "description": "Specifies if the command is the default command for the CLI."
+      "description": "Specifies if the command is the default command for the CLI.",
+      "x-prompt": "Is this the default command?"
     },
     "question": {
       "type": "string",

--- a/packages/nest-commander-schematics/src/question/schema.json
+++ b/packages/nest-commander-schematics/src/question/schema.json
@@ -17,12 +17,14 @@
     "flat": {
       "type": "boolean",
       "default": false,
-      "description": "Flag to indicate if a directory is created."
+      "description": "Flag to indicate if a directory is created.",
+      "x-prompt": "Create a directory?"
     },
     "spec": {
       "type": "boolean",
       "default": true,
-      "description": "Specifies if a spec file is generated."
+      "description": "Specifies if a spec file is generated.",
+      "x-prompt": "Generate spec file as well?"
     }
   }
 }


### PR DESCRIPTION
As we cannot pass the options when using `nest g -c nest-commander-schematics <schematic>`, I think it would be cool if every option has a prompt.