### PR TITLE
refactor: change split args string

### DIFF
--- a/packages/nest-commander/src/command-runner.service.ts
+++ b/packages/nest-commander/src/command-runner.service.ts
@@ -122,7 +122,7 @@ ${cliPluginError(this.options.cliName ?? 'nest-commander', this.options.pluginsA
   ): void {
     const trueArgDefs: Record<string, string> = {};
 
-    const splitArgs = args.split(' ');
+    const splitArgs = args.match(/\[(.*?)]|<(.*?)>/gm) || [];
     for (const arg of splitArgs) {
       let added = false;
       for (const key of Object.keys(argDescriptions).filter((key) => arg.includes(key))) {


### PR DESCRIPTION
At the moment, it is not possible to make a space in the description of commands. This pull request fixes this issue.