### PR TITLE
feat: allow for option choices and sub command aliases

### DIFF
--- a/.changeset/eight-rivers-complain.md
+++ b/.changeset/eight-rivers-complain.md
@@ -1,0 +1,5 @@
+---
+'nest-commander': minor
+---
+
+Added support for aliased subcommands

--- a/.changeset/thick-cheetahs-hang.md
+++ b/.changeset/thick-cheetahs-hang.md
@@ -1,0 +1,7 @@
+---
+'nest-commander': minor
+---
+
+Allow for command options to have defined choices
+
+Option choices are now supported either as a static string array or via the `@OptionChoicesFor()` decorator on a class method. This decorator method approach allows for using a class's injected providers to give the chocies, which means they could come from a database or a config file somewhere if the CLI is set up to handle such a case

--- a/apps/docs/docs/api.md
+++ b/apps/docs/docs/api.md
@@ -19,6 +19,7 @@ This class decorator is pretty much what everything else in this package relies 
 | argsDescription | `Record<string, string>` | false | The description for each argument. It will be used on `--help` as well. |
 | options | `CommandOptions` | false | Extra options to pass to the commander instance. Check [commander's types](https://github.com/tj/commander.js/blob/master/typings/index.d.ts#L713) for more information. |
 | subCommands | `Type<CommandRunner>` | false | Subcommands related to the parent command, e.g.:<br/>`docker compose up` and `docker compose stop`. |
+| aliases | `Array<string>` | false | Aliases for the `SubCommand`. You can pass this array to a `Command` but it will have no effect on the parsing of the command. |
 
 :::note
 
@@ -36,6 +37,16 @@ This method decorator allows for users to pass in extra options for commands def
 | description | `string` | false | The description of the flags and option. Used with the `--help` output. |
 | defaultValue | `string` or `boolean` | false | The default value, if any, for the option. |
 | required | `boolean` | false | Make the option required like an argument and the command fail if the option is not provided. |
+| name | `string` | false | The name of the option for the `CommandRunnerService` (internal) to use when pairing against a `@OptionChoicesFor()` decorator. This has no effect on the help text rendered by commander. |
+| choices | `Array<string>` OR `true` | false | The choices for the option. If `true`, then the `CommandRunnerService` knows to go and find the `@OptionChoicesFor()` decorator that matches the `name` property. If an array, the options are used directly without searching to another method. |
+
+#### @OptionChoicesFor()
+
+This method decorator allows you to get chocies for an `@Option()` in a dynamic manner rather than hard coding them into the `@Option()` decorator. The method this decorator decorates should return a string array of options.
+
+| Property | Type | Requried | Description |
+| --- | --- | --- | --- |
+| name | `string` | true | The name to match back to the `@Option()` decorator. This is how the two decorators are tied together. |
 
 #### @Help()
 

--- a/apps/docs/docs/features/commander.md
+++ b/apps/docs/docs/features/commander.md
@@ -80,6 +80,39 @@ For more details on everything that is possible with options, take a look at [`c
 
 You can also make an option completely required, like an argument, by setting `required: true` in the metadata for the option.
 
+### Setting Choices for your Options
+
+Commander also allows us to set up pre-defined choices for options. To do so we have two options: setting the `choices` array directly as a part of the `@Option()` decorator, or using the `@OptionChoicesFor()` decorator and a class method, similar to the [InquirerService](./inquirer.md). With using the `@OptionChoicesFor()` decorator, we are also able to make use of class providers that are injected into the command via Nest's DI which allows devs to read for the choices from a file or database if that happens to be necessary.
+
+```typescript
+@Command({ name: 'run' })
+export class RunCommand implements CommandRunner {
+  constrtuctor(
+    private readonly choiceProvider: {
+      getChoicesForRun: () => string[];
+    }
+  ) {}
+
+  async run(args: any, options: { runWithColor: 'yes' | 'no' }) {
+    console.log(options);
+  }
+
+  @Options({
+    flags: '-c, --color [runWithColor]',
+    name: 'withColor',
+    description: 'Should the command use color in the output'
+  })
+  parseColorOption(option: string) {
+    return options;
+  }
+
+  @OptionChoicesFor({ name: 'withColor' }) // make sure this matches the `name` of an `@Options()` decorator
+  getColorChoices() {
+    return this.choiceProvider.getChoicesForRun();
+  }
+}
+```
+
 ## Adding Custom Help
 
 By default, `commander` sets help to the `--help` or `-h` flag. If you need extra help added to the command, you can use the `@Help()` decorator on a class method that returns a string. The valid values for the `@Help()` decorator are `before`, `beforeAll`, `after` and `afterAll`, just like for commander's `addHelpText` method.
@@ -111,6 +144,8 @@ export class FooCommand implements CommandRunner {
 ```
 
 and now nest-commander will set up the command so you can call `crun run foo hello!` and the `FooCommand#run` method will be ran instead of `RunCommand#run`. You can also chain commands as deep as you want, by adding `subCommands` to the subcommand's metadata.
+
+Subcommands can also take an `aliases` array for sub command aliases. We could add `aliases: ['f']` to the above `FooCommand` and run it with `run f` instead of `run foo` and get the same result. `aliases` must be passed as an array.
 
 ## The Full Command
 

--- a/integration/index.spec.ts
+++ b/integration/index.spec.ts
@@ -7,6 +7,7 @@ import {
 } from './basic/test/basic.command.spec';
 import { HelpSuite } from './help-tests/test/help.spec';
 import { MultipleCommandSuite } from './multiple/test/multiple.command.spec';
+import { OptionChoiceSuite } from './option-choices/test/option-choices.spec';
 import { PizzaSuite } from './pizza/test/pizza.command.spec';
 import { PluginSuite } from './plugins/test/plugin.command.spec';
 import { SubCommandSuite } from './sub-commands/test/sub-commands.spec';
@@ -27,3 +28,4 @@ SubCommandSuite.run();
 ThisCommandHandlerSuite.run();
 ThisOptionHandlerSuite.run();
 SetQuestionSuite.run();
+OptionChoiceSuite.run();

--- a/integration/option-choices/src/choices-provider.service.ts
+++ b/integration/option-choices/src/choices-provider.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ChoicesProvider {
+  getChoicesForChoicesOption(): string[] {
+    return ['yes', 'no'];
+  }
+}

--- a/integration/option-choices/src/option-choices.command.ts
+++ b/integration/option-choices/src/option-choices.command.ts
@@ -1,0 +1,30 @@
+import { Command, CommandRunner, Option, OptionChoiceFor } from 'nest-commander';
+
+import { LogService } from '../../common/log.service';
+import { ChoicesProvider } from './choices-provider.service';
+
+@Command({ name: 'options-test', options: { isDefault: true } })
+export class OptionsTestCommand implements CommandRunner {
+  constructor(
+    private readonly logger: LogService,
+    private readonly choiceProvider: ChoicesProvider,
+  ) {}
+  async run(_args: never[], options: { choice: string }) {
+    this.logger.log(options);
+  }
+
+  @Option({
+    name: 'choices',
+    choices: true,
+    description: 'The choices you can make for this. "yes" or "no"',
+    flags: '-c, --choice [choices]',
+  })
+  parseChoices(chosen: 'yes' | 'no') {
+    return chosen;
+  }
+
+  @OptionChoiceFor({ name: 'choices' })
+  chosenForChoices() {
+    return this.choiceProvider.getChoicesForChoicesOption();
+  }
+}

--- a/integration/option-choices/src/option-choices.module.ts
+++ b/integration/option-choices/src/option-choices.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { LogService } from '../../common/log.service';
+import { ChoicesProvider } from './choices-provider.service';
+import { OptionsTestCommand } from './option-choices.command';
+
+@Module({
+  providers: [LogService, ChoicesProvider, OptionsTestCommand],
+})
+export class OptionChoicesModule {}

--- a/integration/option-choices/test/option-choices.spec.ts
+++ b/integration/option-choices/test/option-choices.spec.ts
@@ -1,0 +1,29 @@
+import { TestingModule } from '@nestjs/testing';
+import { Stub, stubMethod } from 'hanbi';
+import { CommandTestFactory } from 'nest-commander-testing';
+import { suite } from 'uvu';
+import { equal } from 'uvu/assert';
+import { LogService } from '../../common/log.service';
+import { OptionChoicesModule } from '../src/option-choices.module';
+
+export const OptionChoiceSuite =
+  suite<{ commandInstance: TestingModule; logMock: Stub<typeof console.log> }>(
+    'OptionChoice Suite',
+  );
+OptionChoiceSuite.before(async (context) => {
+  context.logMock = stubMethod(console, 'log');
+  context.commandInstance = await CommandTestFactory.createTestingCommand({
+    imports: [OptionChoicesModule],
+  })
+    .overrideProvider(LogService)
+    .useValue({ log: context.logMock.handler })
+    .compile();
+});
+OptionChoiceSuite('Send in option "yes"', async ({ commandInstance, logMock }) => {
+  await CommandTestFactory.run(commandInstance, ['-c', 'yes']);
+  equal(logMock.firstCall?.args[0], { choice: 'yes' });
+});
+OptionChoiceSuite('Send in option "no"', async ({ commandInstance, logMock }) => {
+  await CommandTestFactory.run(commandInstance, ['-c', 'no']);
+  equal(logMock.firstCall?.args[0], { choice: 'no' });
+});

--- a/integration/sub-commands/src/mid-2.command.ts
+++ b/integration/sub-commands/src/mid-2.command.ts
@@ -2,7 +2,7 @@ import { CommandRunner, SubCommand } from 'nest-commander';
 
 import { LogService } from '../../common/log.service';
 
-@SubCommand({ name: 'mid-2' })
+@SubCommand({ name: 'mid-2', aliases: ['m'] })
 export class Mid2Command implements CommandRunner {
   constructor(private readonly log: LogService) {}
 

--- a/integration/sub-commands/test/sub-commands.spec.ts
+++ b/integration/sub-commands/test/sub-commands.spec.ts
@@ -54,3 +54,10 @@ for (const command of ['mid-1', 'mid-2', 'bottom']) {
     },
   );
 }
+SubCommandSuite(
+  'SubCommand mid-2 should be callable with "m"',
+  async ({ commandInstance, logMock }) => {
+    await CommandTestFactory.run(commandInstance, ['top', 'm']);
+    equal(logMock.firstCall?.args[0], 'top mid-2 command');
+  },
+);

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@typescript-eslint/parser": "5.16.0",
     "c8": "^7.11.0",
     "clsx": "1.1.1",
-    "commander": "9.1.0",
+    "commander": "^8",
     "conventional-changelog-cli": "2.2.2",
     "cosmiconfig": "7.0.1",
     "cz-conventional-changelog": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@typescript-eslint/parser": "5.16.0",
     "c8": "^7.11.0",
     "clsx": "1.1.1",
-    "commander": "8.3.0",
+    "commander": "9.1.0",
     "conventional-changelog-cli": "2.2.2",
     "cosmiconfig": "7.0.1",
     "cz-conventional-changelog": "3.3.0",

--- a/packages/nest-commander/package.json
+++ b/packages/nest-commander/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/jmcdo29/nest-commander#readme",
   "dependencies": {
     "@golevelup/nestjs-discovery": "3.0.0",
-    "commander": "9.1.0",
+    "commander": "8.3.0",
     "cosmiconfig": "7.0.1",
     "inquirer": "8.2.1"
   },

--- a/packages/nest-commander/package.json
+++ b/packages/nest-commander/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/jmcdo29/nest-commander#readme",
   "dependencies": {
     "@golevelup/nestjs-discovery": "3.0.0",
-    "commander": "8.3.0",
+    "commander": "9.1.0",
     "cosmiconfig": "7.0.1",
     "inquirer": "8.2.1"
   },

--- a/packages/nest-commander/src/command-runner.interface.ts
+++ b/packages/nest-commander/src/command-runner.interface.ts
@@ -42,6 +42,12 @@ export interface OptionMetadata {
   description?: string;
   defaultValue?: string | boolean;
   required?: boolean;
+  name?: string;
+  choices?: string[] | true;
+}
+
+export interface OptionChoiceForMetadata {
+  name: string;
 }
 
 export interface RunnerMeta {

--- a/packages/nest-commander/src/command-runner.interface.ts
+++ b/packages/nest-commander/src/command-runner.interface.ts
@@ -34,6 +34,7 @@ export interface CommandMetadata {
   argsDescription?: Record<string, string>;
   options?: CommandOptions;
   subCommands?: Array<Type<CommandRunner>>;
+  aliases?: string[];
 }
 
 export interface OptionMetadata {

--- a/packages/nest-commander/src/command-runner.service.ts
+++ b/packages/nest-commander/src/command-runner.service.ts
@@ -95,6 +95,7 @@ ${cliPluginError(this.options.cliName ?? 'nest-commander', this.options.pluginsA
     for (const help of command.help ?? []) {
       newCommand.addHelpText(help.meta, help.discoveredMethod.handler.bind(command.instance));
     }
+    command.command.aliases?.forEach((alias) => newCommand.alias(alias));
     newCommand.action(() =>
       command.instance.run.call(command.instance, newCommand.args, newCommand.opts()),
     );

--- a/packages/nest-commander/src/command.decorators.ts
+++ b/packages/nest-commander/src/command.decorators.ts
@@ -3,6 +3,7 @@ import {
   CommandMetadata,
   CommandRunner,
   HelpOptions,
+  OptionChoiceForMetadata,
   OptionMetadata,
   QuestionMetadata,
   QuestionNameMetadata,
@@ -14,6 +15,7 @@ import {
   DefaultMeta,
   HelpMeta,
   MessageMeta,
+  OptionChoiceMeta,
   OptionMeta,
   QuestionMeta,
   QuestionSetMeta,
@@ -54,6 +56,10 @@ export const SubCommand = (options: CommandMetadata): CommandDecorator => {
 
 export const Option = (options: OptionMetadata): MethodDecorator => {
   return applyMethodMetadata(options, OptionMeta);
+};
+
+export const OptionChoiceFor = (options: OptionChoiceForMetadata): MethodDecorator => {
+  return applyMethodMetadata(options, OptionChoiceMeta);
 };
 
 export const QuestionSet = (options: QuestionNameMetadata): ClassDecorator => {

--- a/packages/nest-commander/src/constants.ts
+++ b/packages/nest-commander/src/constants.ts
@@ -9,6 +9,7 @@ const questionMetaBuilder = (suffix: string): string => {
 export const CommandMeta = metaKeyBuilder('Command:Meta');
 export const SubCommandMeta = metaKeyBuilder('Subcommand:Meta');
 export const OptionMeta = metaKeyBuilder('Option:Meta');
+export const OptionChoiceMeta = metaKeyBuilder('OptionChoice:Meta');
 export const QuestionSetMeta = metaKeyBuilder('QuestionSet:Meta');
 export const QuestionMeta = questionMetaBuilder('Meta');
 export const ValidateMeta = questionMetaBuilder('Validate');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ importers:
       '@typescript-eslint/parser': 5.16.0
       c8: ^7.11.0
       clsx: 1.1.1
-      commander: 8.3.0
+      commander: 9.1.0
       conventional-changelog-cli: 2.2.2
       cosmiconfig: 7.0.1
       cz-conventional-changelog: 3.3.0
@@ -85,7 +85,7 @@ importers:
       '@typescript-eslint/parser': 5.16.0_eslint@8.11.0+typescript@4.6.2
       c8: 7.11.0
       clsx: 1.1.1
-      commander: 8.3.0
+      commander: 9.1.0
       conventional-changelog-cli: 2.2.2
       cosmiconfig: 7.0.1
       cz-conventional-changelog: 3.3.0_@swc+core@1.2.159
@@ -5783,6 +5783,11 @@ packages:
   /commander/8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
+
+  /commander/9.1.0:
+    resolution: {integrity: sha512-i0/MaqBtdbnJ4XQs4Pmyb+oFQl+q0lsAmokVUH92SlSw4fkeAcG3bVon+Qt7hmtF+u3Het6o4VgrcY3qAoEB6w==}
+    engines: {node: ^12.20.0 || >=14}
+    dev: true
 
   /commitizen/4.2.4_@swc+core@1.2.159:
     resolution: {integrity: sha512-LlZChbDzg3Ir3O2S7jSo/cgWp5/QwylQVr59K4xayVq8S4/RdKzSyJkghAiZZHfhh5t4pxunUoyeg0ml1q/7aw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ importers:
       '@typescript-eslint/parser': 5.16.0
       c8: ^7.11.0
       clsx: 1.1.1
-      commander: 9.1.0
+      commander: ^8
       conventional-changelog-cli: 2.2.2
       cosmiconfig: 7.0.1
       cz-conventional-changelog: 3.3.0
@@ -85,7 +85,7 @@ importers:
       '@typescript-eslint/parser': 5.16.0_eslint@8.11.0+typescript@4.6.2
       c8: 7.11.0
       clsx: 1.1.1
-      commander: 9.1.0
+      commander: 8.3.0
       conventional-changelog-cli: 2.2.2
       cosmiconfig: 7.0.1
       cz-conventional-changelog: 3.3.0_@swc+core@1.2.159
@@ -5783,11 +5783,6 @@ packages:
   /commander/8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
-
-  /commander/9.1.0:
-    resolution: {integrity: sha512-i0/MaqBtdbnJ4XQs4Pmyb+oFQl+q0lsAmokVUH92SlSw4fkeAcG3bVon+Qt7hmtF+u3Het6o4VgrcY3qAoEB6w==}
-    engines: {node: ^12.20.0 || >=14}
-    dev: true
 
   /commitizen/4.2.4_@swc+core@1.2.159:
     resolution: {integrity: sha512-LlZChbDzg3Ir3O2S7jSo/cgWp5/QwylQVr59K4xayVq8S4/RdKzSyJkghAiZZHfhh5t4pxunUoyeg0ml1q/7aw==}


### PR DESCRIPTION
Option choices are now supported either as a static string array
or via the `@OptionChoicesFor()` decorator on a class method.
This decorator method approach allows for using a class's injected
providers to give the chocies, which means they could come from a
database or a config file somewhere if the CLI is set up to handle
such a case

closes #327 #360