### PR TITLE
feat: allow for access to original command instance

### DIFF
--- a/.changeset/good-otters-reply.md
+++ b/.changeset/good-otters-reply.md
@@ -1,0 +1,5 @@
+---
+'nest-commander': patch
+---
+
+Ensure the parser for choices is always called

--- a/.changeset/itchy-ads-nail.md
+++ b/.changeset/itchy-ads-nail.md
@@ -1,0 +1,10 @@
+---
+'nest-commander': major
+'nest-commander-testing': major
+---
+
+Migrate `CommandRunner` from interface to abstract class and add `.command`
+
+This change was made so that devs could access `this.command` inside the `CommandRunner` instance and have access to the base command object from commander. This allows for access to the `help` commands in a programatic fashion.
+
+To update to this version, any `implements CommandRunner` should be changed to `extends CommandRunner`. If there is a `constructor` to the `CommandRunner` then it should also use `super()`.

--- a/.changeset/red-trains-speak.md
+++ b/.changeset/red-trains-speak.md
@@ -1,0 +1,5 @@
+---
+'nest-commander': minor
+---
+
+Upgrade commander to v9.4.0

--- a/integration/basic/src/basic.command.ts
+++ b/integration/basic/src/basic.command.ts
@@ -8,8 +8,10 @@ interface BasicCommandOptions {
 }
 
 @Command({ name: 'basic', description: 'A parameter parse' })
-export class BasicCommand implements CommandRunner {
-  constructor(private readonly logService: LogService) {}
+export class BasicCommand extends CommandRunner {
+  constructor(private readonly logService: LogService) {
+    super();
+  }
 
   async run(passedParam: string[], options?: BasicCommandOptions): Promise<void> {
     if (options?.boolean !== undefined && options?.boolean !== null) {

--- a/integration/basic/test/basic.command.spec.ts
+++ b/integration/basic/test/basic.command.spec.ts
@@ -79,7 +79,7 @@ UnknownCommandSuite('should not throw an error', async () => {
   } finally {
     stdErrSpy.restore();
     stdoutSpy.restore();
-    equal(stdErrSpy.firstCall?.args, ["error: unknown option '--help'\n"]);
+    equal(stdErrSpy.firstCall?.args, ["error: unknown option '--help'\n(Did you mean --help?)\n"]);
     equal(stdoutSpy.firstCall?.args, [outputHelp]);
     exitSpy.restore();
   }
@@ -100,7 +100,7 @@ UnknownCommandSuite('should not throw an error', async () => {
   } finally {
     stdErrSpy.restore();
     stdoutSpy.restore();
-    equal(stdErrSpy.firstCall?.args, ["error: unknown option '--help'\n"]);
+    equal(stdErrSpy.firstCall?.args, ["error: unknown option '--help'\n(Did you mean --help?)\n"]);
     equal(stdoutSpy.firstCall?.args, [outputHelp]);
     exitSpy.restore();
   }

--- a/integration/dot-command/src/dot.command.ts
+++ b/integration/dot-command/src/dot.command.ts
@@ -1,0 +1,10 @@
+import { Command, CommandRunner } from 'nest-commander';
+
+@Command({ name: 'dot', options: { isDefault: true } })
+export class DotCommand extends CommandRunner {
+  async run() {
+    if (!this.command) {
+      throw new Error('No .command property set');
+    }
+  }
+}

--- a/integration/dot-command/src/dot.module.ts
+++ b/integration/dot-command/src/dot.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { DotCommand } from './dot.command';
+
+@Module({
+  providers: [DotCommand],
+})
+export class DotModule {}

--- a/integration/dot-command/test/dot.command.spec.ts
+++ b/integration/dot-command/test/dot.command.spec.ts
@@ -1,0 +1,17 @@
+import { CommandTestFactory } from 'nest-commander-testing';
+import { suite } from 'uvu';
+import { ok, unreachable } from 'uvu/assert';
+import { DotModule } from '../src/dot.module';
+
+export const DotCommandSuite = suite('DotCommand');
+DotCommandSuite('Command does not throw error', async () => {
+  try {
+    const commandInstance = await CommandTestFactory.createTestingCommand({
+      imports: [DotModule],
+    }).compile();
+    await CommandTestFactory.run(commandInstance);
+    ok(true);
+  } catch (err) {
+    unreachable('If we got here the .command property was not populated');
+  }
+});

--- a/integration/help-tests/src/after-after-all.command.ts
+++ b/integration/help-tests/src/after-after-all.command.ts
@@ -4,7 +4,7 @@ import { Command, CommandRunner, Help } from 'nest-commander';
   name: 'after-after-all',
   description: 'after after all',
 })
-export class AfterAfterAllCommand implements CommandRunner {
+export class AfterAfterAllCommand extends CommandRunner {
   async run() {
     /* no op */
   }

--- a/integration/help-tests/src/after-all.command.ts
+++ b/integration/help-tests/src/after-all.command.ts
@@ -4,7 +4,7 @@ import { Command, CommandRunner, Help } from 'nest-commander';
   name: 'after-all',
   description: 'after all',
 })
-export class AfterAllCommand implements CommandRunner {
+export class AfterAllCommand extends CommandRunner {
   async run() {
     /* no op */
   }

--- a/integration/help-tests/src/after.command.ts
+++ b/integration/help-tests/src/after.command.ts
@@ -4,7 +4,7 @@ import { Command, CommandRunner, Help } from 'nest-commander';
   name: 'after',
   description: 'after',
 })
-export class AfterCommand implements CommandRunner {
+export class AfterCommand extends CommandRunner {
   async run() {
     /* no op */
   }

--- a/integration/help-tests/src/before-after.command.ts
+++ b/integration/help-tests/src/before-after.command.ts
@@ -4,7 +4,7 @@ import { Command, CommandRunner, Help } from 'nest-commander';
   name: 'before-after',
   description: 'before-after',
 })
-export class BeforeAfterCommand implements CommandRunner {
+export class BeforeAfterCommand extends CommandRunner {
   async run() {
     /* no op */
   }

--- a/integration/help-tests/src/before-all.command.ts
+++ b/integration/help-tests/src/before-all.command.ts
@@ -1,7 +1,7 @@
 import { Command, CommandRunner, Help } from 'nest-commander';
 
 @Command({ name: 'before-all', description: 'before-all' })
-export class BeforeAllCommand implements CommandRunner {
+export class BeforeAllCommand extends CommandRunner {
   async run() {
     /* no op */
   }

--- a/integration/help-tests/src/before-before-all.command.ts
+++ b/integration/help-tests/src/before-before-all.command.ts
@@ -4,7 +4,7 @@ import { Command, CommandRunner, Help } from 'nest-commander';
   name: 'before-before-all',
   description: 'before-before-all',
 })
-export class BeforeBeforeAllCommand implements CommandRunner {
+export class BeforeBeforeAllCommand extends CommandRunner {
   async run() {
     /* no op */
   }

--- a/integration/help-tests/src/before.command.ts
+++ b/integration/help-tests/src/before.command.ts
@@ -1,7 +1,7 @@
 import { Command, CommandRunner, Help } from 'nest-commander';
 
 @Command({ name: 'before', description: 'before' })
-export class BeforeCommand implements CommandRunner {
+export class BeforeCommand extends CommandRunner {
   async run() {
     /* no op */
   }

--- a/integration/help-tests/src/foo.command.ts
+++ b/integration/help-tests/src/foo.command.ts
@@ -7,8 +7,10 @@ import { LogService } from '../../common/log.service';
     isDefault: true,
   },
 })
-export class FooCommand implements CommandRunner {
-  constructor(private readonly logger: LogService) {}
+export class FooCommand extends CommandRunner {
+  constructor(private readonly logger: LogService) {
+    super();
+  }
   async run(inputs: any, options: any) {
     this.logger.log(inputs, options);
   }

--- a/integration/index.spec.ts
+++ b/integration/index.spec.ts
@@ -5,6 +5,7 @@ import {
   StringCommandSuite,
   UnknownCommandSuite,
 } from './basic/test/basic.command.spec';
+import { DotCommandSuite } from './dot-command/test/dot.command.spec';
 import { HelpSuite } from './help-tests/test/help.spec';
 import { MultipleCommandSuite } from './multiple/test/multiple.command.spec';
 import { OptionChoiceSuite } from './option-choices/test/option-choices.spec';
@@ -29,3 +30,4 @@ ThisCommandHandlerSuite.run();
 ThisOptionHandlerSuite.run();
 SetQuestionSuite.run();
 OptionChoiceSuite.run();
+DotCommandSuite.run();

--- a/integration/multiple/src/bar.command.ts
+++ b/integration/multiple/src/bar.command.ts
@@ -2,8 +2,10 @@ import { Command, CommandRunner } from 'nest-commander';
 import { LogService } from './../../common/log.service';
 
 @Command({ name: 'bar', options: { isDefault: false } })
-export class BarCommand implements CommandRunner {
-  constructor(private readonly logService: LogService) {}
+export class BarCommand extends CommandRunner {
+  constructor(private readonly logService: LogService) {
+    super();
+  }
 
   async run(): Promise<void> {
     this.logService.log('bar');

--- a/integration/multiple/src/foo.command.ts
+++ b/integration/multiple/src/foo.command.ts
@@ -2,8 +2,10 @@ import { Command, CommandRunner } from 'nest-commander';
 import { LogService } from './../../common/log.service';
 
 @Command({ name: 'foo', options: { isDefault: true } })
-export class FooCommand implements CommandRunner {
-  constructor(private readonly logService: LogService) {}
+export class FooCommand extends CommandRunner {
+  constructor(private readonly logService: LogService) {
+    super();
+  }
 
   async run(): Promise<void> {
     this.logService.log('foo');

--- a/integration/option-choices/src/option-choices.command.ts
+++ b/integration/option-choices/src/option-choices.command.ts
@@ -4,11 +4,13 @@ import { LogService } from '../../common/log.service';
 import { ChoicesProvider } from './choices-provider.service';
 
 @Command({ name: 'options-test', options: { isDefault: true } })
-export class OptionsTestCommand implements CommandRunner {
+export class OptionsTestCommand extends CommandRunner {
   constructor(
     private readonly logger: LogService,
     private readonly choiceProvider: ChoicesProvider,
-  ) {}
+  ) {
+    super();
+  }
   async run(_args: never[], options: { choice: string }) {
     this.logger.log(options);
   }

--- a/integration/option-choices/src/option-choices.command.ts
+++ b/integration/option-choices/src/option-choices.command.ts
@@ -29,4 +29,14 @@ export class OptionsTestCommand extends CommandRunner {
   chosenForChoices() {
     return this.choiceProvider.getChoicesForChoicesOption();
   }
+
+  @Option({
+    choices: ['yes', 'no'],
+    description: 'This is here to verify the parser is called',
+    flags: '-v, [verify]',
+  })
+  parseVerifyChoices(verifyChoice: string) {
+    this.logger.log('verify choice parser');
+    return verifyChoice;
+  }
 }

--- a/integration/option-choices/test/option-choices.spec.ts
+++ b/integration/option-choices/test/option-choices.spec.ts
@@ -1,5 +1,5 @@
 import { TestingModule } from '@nestjs/testing';
-import { spy, Stub, stubMethod } from 'hanbi';
+import { spy, Stub } from 'hanbi';
 import { CommandTestFactory } from 'nest-commander-testing';
 import { suite } from 'uvu';
 import { equal } from 'uvu/assert';
@@ -31,8 +31,6 @@ OptionChoiceSuite('Send in option "no"', async ({ commandInstance, logMock }) =>
   equal(logMock.firstCall?.args[0], { choice: 'no' });
 });
 OptionChoiceSuite('Send in "yes" for verify', async ({ commandInstance, logMock }) => {
-  logMock.passThrough();
-  logMock.calls.forEach((call) => console.log(call.args));
   await CommandTestFactory.run(commandInstance, ['-v', 'yes']);
   equal(logMock.firstCall?.args[0], 'verify choice parser');
 });

--- a/integration/option-choices/test/option-choices.spec.ts
+++ b/integration/option-choices/test/option-choices.spec.ts
@@ -1,23 +1,26 @@
 import { TestingModule } from '@nestjs/testing';
-import { Stub, stubMethod } from 'hanbi';
+import { spy, Stub, stubMethod } from 'hanbi';
 import { CommandTestFactory } from 'nest-commander-testing';
 import { suite } from 'uvu';
 import { equal } from 'uvu/assert';
 import { LogService } from '../../common/log.service';
 import { OptionChoicesModule } from '../src/option-choices.module';
 
-export const OptionChoiceSuite =
-  suite<{ commandInstance: TestingModule; logMock: Stub<typeof console.log> }>(
-    'OptionChoice Suite',
-  );
+export const OptionChoiceSuite = suite<{
+  commandInstance: TestingModule;
+  logMock: Stub<typeof console.log>;
+}>('OptionChoice Suite');
 OptionChoiceSuite.before(async (context) => {
-  context.logMock = stubMethod(console, 'log');
+  context.logMock = spy();
   context.commandInstance = await CommandTestFactory.createTestingCommand({
     imports: [OptionChoicesModule],
   })
     .overrideProvider(LogService)
     .useValue({ log: context.logMock.handler })
     .compile();
+});
+OptionChoiceSuite.before.each(({ logMock }) => {
+  logMock.reset();
 });
 OptionChoiceSuite('Send in option "yes"', async ({ commandInstance, logMock }) => {
   await CommandTestFactory.run(commandInstance, ['-c', 'yes']);
@@ -27,3 +30,11 @@ OptionChoiceSuite('Send in option "no"', async ({ commandInstance, logMock }) =>
   await CommandTestFactory.run(commandInstance, ['-c', 'no']);
   equal(logMock.firstCall?.args[0], { choice: 'no' });
 });
+OptionChoiceSuite('Send in "yes" for verify', async ({ commandInstance, logMock }) => {
+  logMock.passThrough();
+  logMock.calls.forEach((call) => console.log(call.args));
+  await CommandTestFactory.run(commandInstance, ['-v', 'yes']);
+  equal(logMock.firstCall?.args[0], 'verify choice parser');
+});
+
+OptionChoiceSuite.run();

--- a/integration/pizza/src/pizza.command.ts
+++ b/integration/pizza/src/pizza.command.ts
@@ -2,8 +2,10 @@ import { Command, CommandRunner, InquirerService } from 'nest-commander';
 import { PizzaOptions } from './pizza.interface';
 
 @Command({ name: 'pizza', options: { isDefault: true } })
-export class PizzaCommand implements CommandRunner {
-  constructor(private readonly inquirerService: InquirerService) {}
+export class PizzaCommand extends CommandRunner {
+  constructor(private readonly inquirerService: InquirerService) {
+    super();
+  }
   async run(_inputs: string[], options?: PizzaOptions): Promise<void> {
     options = await this.inquirerService.ask('pizza', options);
     console.log(options);

--- a/integration/plugins/src/foo.command.ts
+++ b/integration/plugins/src/foo.command.ts
@@ -5,8 +5,10 @@ import { LogService } from '../../common/log.service';
   name: 'phooey',
   description: 'This is a phooey command.',
 })
-export class FooCommand implements CommandRunner {
-  constructor(private readonly log: LogService) {}
+export class FooCommand extends CommandRunner {
+  constructor(private readonly log: LogService) {
+    super();
+  }
 
   async run() {
     this.log.log('Foo!');

--- a/integration/plugins/src/plugin/plugin.command.ts
+++ b/integration/plugins/src/plugin/plugin.command.ts
@@ -1,7 +1,7 @@
 import { Command, CommandRunner } from 'nest-commander';
 
 @Command({ name: 'plug' })
-export class PluginCommand implements CommandRunner {
+export class PluginCommand extends CommandRunner {
   async run() {
     console.log('This is from the plugin!');
   }

--- a/integration/sub-commands/src/bottom.command.ts
+++ b/integration/sub-commands/src/bottom.command.ts
@@ -3,8 +3,10 @@ import { CommandRunner, SubCommand } from 'nest-commander';
 import { LogService } from '../../common/log.service';
 
 @SubCommand({ name: 'bottom' })
-export class BottomCommand implements CommandRunner {
-  constructor(private readonly log: LogService) {}
+export class BottomCommand extends CommandRunner {
+  constructor(private readonly log: LogService) {
+    super();
+  }
 
   async run() {
     this.log.log('top mid-1 bottom command');

--- a/integration/sub-commands/src/mid-1.command.ts
+++ b/integration/sub-commands/src/mid-1.command.ts
@@ -4,8 +4,10 @@ import { LogService } from '../../common/log.service';
 import { BottomCommand } from './bottom.command';
 
 @SubCommand({ name: 'mid-1', subCommands: [BottomCommand] })
-export class Mid1Command implements CommandRunner {
-  constructor(private readonly log: LogService) {}
+export class Mid1Command extends CommandRunner {
+  constructor(private readonly log: LogService) {
+    super();
+  }
 
   async run() {
     this.log.log('top mid-1 command');

--- a/integration/sub-commands/src/mid-2.command.ts
+++ b/integration/sub-commands/src/mid-2.command.ts
@@ -3,8 +3,10 @@ import { CommandRunner, SubCommand } from 'nest-commander';
 import { LogService } from '../../common/log.service';
 
 @SubCommand({ name: 'mid-2', aliases: ['m'] })
-export class Mid2Command implements CommandRunner {
-  constructor(private readonly log: LogService) {}
+export class Mid2Command extends CommandRunner {
+  constructor(private readonly log: LogService) {
+    super();
+  }
 
   async run() {
     this.log.log('top mid-2 command');

--- a/integration/sub-commands/src/top.command.ts
+++ b/integration/sub-commands/src/top.command.ts
@@ -5,8 +5,10 @@ import { Mid1Command } from './mid-1.command';
 import { Mid2Command } from './mid-2.command';
 
 @Command({ name: 'top', arguments: '[name]', subCommands: [Mid1Command, Mid2Command] })
-export class TopCommand implements CommandRunner {
-  constructor(private readonly log: LogService) {}
+export class TopCommand extends CommandRunner {
+  constructor(private readonly log: LogService) {
+    super();
+  }
 
   async run(inputs: string[]) {
     this.log.log('top command');

--- a/integration/this-command/src/this-command.command.ts
+++ b/integration/this-command/src/this-command.command.ts
@@ -2,8 +2,10 @@ import { Command, CommandRunner } from 'nest-commander';
 import { LogService } from '../../common/log.service';
 
 @Command({ name: 'this-command', arguments: '<with-value>' })
-export class ThisCommandCommand implements CommandRunner {
-  constructor(private readonly log: LogService) {}
+export class ThisCommandCommand extends CommandRunner {
+  constructor(private readonly log: LogService) {
+    super();
+  }
 
   async run(params: string[]) {
     this.logHandler(params);

--- a/integration/this-handler/src/this-handler.command.ts
+++ b/integration/this-handler/src/this-handler.command.ts
@@ -6,8 +6,10 @@ import { LogService } from '../../common/log.service';
   description: 'Just adding a description for coverage',
   options: { isDefault: true },
 })
-export class ThisHandlerCommand implements CommandRunner {
-  constructor(private readonly log: LogService) {}
+export class ThisHandlerCommand extends CommandRunner {
+  constructor(private readonly log: LogService) {
+    super();
+  }
 
   async run(params: string[], options: Record<string, string>) {
     this.logHandler(options);

--- a/integration/with-questions/src/hello.command.ts
+++ b/integration/with-questions/src/hello.command.ts
@@ -3,8 +3,10 @@ import { LogService } from '../../common/log.service';
 import { HelloOptions } from './hello.interface';
 
 @Command({ name: 'hello', options: { isDefault: true } })
-export class HelloCommand implements CommandRunner {
-  constructor(private readonly inquirer: InquirerService, private readonly logger: LogService) {}
+export class HelloCommand extends CommandRunner {
+  constructor(private readonly inquirer: InquirerService, private readonly logger: LogService) {
+    super();
+  }
 
   async run(_inputs: string[], options?: HelloOptions): Promise<void> {
     options = await this.inquirer.ask('hello', options);

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@typescript-eslint/parser": "5.30.7",
     "c8": "7.12.0",
     "clsx": "1.2.1",
-    "commander": "8.3.0",
+    "commander": "9.4.0",
     "conventional-changelog-cli": "2.2.2",
     "cosmiconfig": "7.0.1",
     "cz-conventional-changelog": "3.3.0",

--- a/packages/nest-commander-testing/package.json
+++ b/packages/nest-commander-testing/package.json
@@ -27,6 +27,6 @@
     "@nestjs/common": "^8.0.0 || ^9.0.0",
     "@nestjs/core": "^8.0.0 || ^9.0.0",
     "@nestjs/testing": "^8.0.0 || ^9.0.0",
-    "nest-commander": "^2.0.0"
+    "nest-commander": "^3.0.0"
   }
 }

--- a/packages/nest-commander/package.json
+++ b/packages/nest-commander/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://nest-commander.jaymcdoniel.dev",
   "dependencies": {
     "@golevelup/nestjs-discovery": "3.0.0",
-    "commander": "8.3.0",
+    "commander": "9.4.0",
     "cosmiconfig": "7.0.1",
     "inquirer": "8.2.4"
   },

--- a/packages/nest-commander/src/command-runner.interface.ts
+++ b/packages/nest-commander/src/command-runner.interface.ts
@@ -45,7 +45,7 @@ export interface CommandMetadata {
 export interface OptionMetadata {
   flags: string;
   description?: string;
-  defaultValue?: string | boolean;
+  defaultValue?: string | boolean | number;
   required?: boolean;
   name?: string;
   choices?: string[] | true;

--- a/packages/nest-commander/src/command-runner.interface.ts
+++ b/packages/nest-commander/src/command-runner.interface.ts
@@ -1,6 +1,6 @@
 import { DiscoveredMethodWithMeta } from '@golevelup/nestjs-discovery';
 import { Type } from '@nestjs/common';
-import { CommandOptions } from 'commander';
+import { Command, CommandOptions } from 'commander';
 import type {
   CheckboxQuestion,
   ConfirmQuestion,
@@ -23,8 +23,13 @@ export type InquirerKeysWithPossibleFunctionTypes =
 
 type InquirerQuestionWithoutFilter<T> = Omit<T, 'filter'>;
 
-export interface CommandRunner {
-  run(passedParams: string[], options?: Record<string, any>): Promise<void>;
+export abstract class CommandRunner {
+  protected command!: Command;
+  public setCommand(command: Command): this {
+    this.command = command;
+    return this;
+  }
+  abstract run(passedParams: string[], options?: Record<string, any>): Promise<void>;
 }
 
 export interface CommandMetadata {

--- a/packages/nest-commander/src/command-runner.service.ts
+++ b/packages/nest-commander/src/command-runner.service.ts
@@ -101,6 +101,7 @@ ${cliPluginError(this.options.cliName ?? 'nest-commander', this.options.pluginsA
       const handler = option.discoveredMethod.handler.bind(command.instance);
       const commandOption = new Option(flags, description)
         .default(defaultValue)
+        .preset(defaultValue)
         .makeOptionMandatory(required)
         .argParser(handler);
       // choices can be a true boolean or an array of string options for commander.

--- a/packages/nest-commander/src/command-runner.service.ts
+++ b/packages/nest-commander/src/command-runner.service.ts
@@ -102,8 +102,7 @@ ${cliPluginError(this.options.cliName ?? 'nest-commander', this.options.pluginsA
       const commandOption = new Option(flags, description)
         .default(defaultValue)
         .preset(defaultValue)
-        .makeOptionMandatory(required)
-        .argParser(handler);
+        .makeOptionMandatory(required);
       // choices can be a true boolean or an array of string options for commander.
       // If a boolean, then we know that we are expected to go find the OptionChoiceFOr method.
       if (choices === true || (Array.isArray(choices) && choices.length)) {
@@ -123,6 +122,7 @@ ${cliPluginError(this.options.cliName ?? 'nest-commander', this.options.pluginsA
         }
         commandOption.choices(optionChoices);
       }
+      commandOption.argParser(handler);
       newCommand.addOption(commandOption);
     }
     for (const help of command.help ?? []) {

--- a/packages/nest-commander/src/command-runner.service.ts
+++ b/packages/nest-commander/src/command-runner.service.ts
@@ -80,6 +80,7 @@ ${cliPluginError(this.options.cliName ?? 'nest-commander', this.options.pluginsA
 
   private async buildCommand(command: RunnerMeta): Promise<Command> {
     const newCommand = this.commander.createCommand(command.command.name);
+    command.instance.setCommand(newCommand);
     if (command.command.arguments) {
       this.mapArgumentDescriptions(
         newCommand,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
       '@typescript-eslint/parser': 5.30.7
       c8: 7.12.0
       clsx: 1.2.1
-      commander: 8.3.0
+      commander: 9.4.0
       conventional-changelog-cli: 2.2.2
       cosmiconfig: 7.0.1
       cz-conventional-changelog: 3.3.0
@@ -84,7 +84,7 @@ importers:
       '@typescript-eslint/parser': 5.30.7_he2ccbldppg44uulnyq4rwocfa
       c8: 7.12.0
       clsx: 1.2.1
-      commander: 8.3.0
+      commander: 9.4.0
       conventional-changelog-cli: 2.2.2
       cosmiconfig: 7.0.1
       cz-conventional-changelog: 3.3.0_@swc+core@1.2.218
@@ -110,12 +110,12 @@ importers:
   packages/nest-commander:
     specifiers:
       '@golevelup/nestjs-discovery': 3.0.0
-      commander: 8.3.0
+      commander: 9.4.0
       cosmiconfig: 7.0.1
       inquirer: 8.2.4
     dependencies:
       '@golevelup/nestjs-discovery': 3.0.0
-      commander: 8.3.0
+      commander: 9.4.0
       cosmiconfig: 7.0.1
       inquirer: 8.2.4
 
@@ -2148,7 +2148,7 @@ packages:
       combine-promises: 1.1.0
       commander: 5.1.0
       copy-webpack-plugin: 11.0.0_webpack@5.73.0
-      core-js: 3.23.5
+      core-js: 3.24.0
       css-loader: 6.7.1_webpack@5.73.0
       css-minimizer-webpack-plugin: 4.0.0_ym7haxui4mhsv4z74sxfalk3f4
       cssnano: 5.1.12_postcss@8.4.14
@@ -2246,7 +2246,7 @@ packages:
       combine-promises: 1.1.0
       commander: 5.1.0
       copy-webpack-plugin: 11.0.0_webpack@5.73.0
-      core-js: 3.23.5
+      core-js: 3.24.0
       css-loader: 6.7.1_webpack@5.73.0
       css-minimizer-webpack-plugin: 4.0.0_ym7haxui4mhsv4z74sxfalk3f4
       cssnano: 5.1.12_postcss@8.4.14
@@ -5734,11 +5734,6 @@ packages:
   /cli-spinners/2.6.1:
     resolution: {integrity: sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==}
     engines: {node: '>=6'}
-    dev: true
-
-  /cli-spinners/2.7.0:
-    resolution: {integrity: sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==}
-    engines: {node: '>=6'}
 
   /cli-table3/0.6.2:
     resolution: {integrity: sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==}
@@ -5889,11 +5884,11 @@ packages:
   /commander/8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
-
-  /commander/9.3.0:
-    resolution: {integrity: sha512-hv95iU5uXPbK83mjrJKuZyFM/LBAoCV/XhVGkS5Je6tl7sxr6A0ITMw5WoRV46/UaJ46Nllm3Xt7IaJhXTIkzw==}
-    engines: {node: ^12.20.0 || >=14}
     dev: true
+
+  /commander/9.4.0:
+    resolution: {integrity: sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==}
+    engines: {node: ^12.20.0 || >=14}
 
   /commitizen/4.2.4_@swc+core@1.2.218:
     resolution: {integrity: sha512-LlZChbDzg3Ir3O2S7jSo/cgWp5/QwylQVr59K4xayVq8S4/RdKzSyJkghAiZZHfhh5t4pxunUoyeg0ml1q/7aw==}
@@ -6229,8 +6224,8 @@ packages:
     requiresBuild: true
     dev: true
 
-  /core-js/3.23.5:
-    resolution: {integrity: sha512-7Vh11tujtAZy82da4duVreQysIoO2EvVrur7y6IzZkH1IHPSekuDi8Vuw1+YKjkbfWLRD7Nc9ICQ/sIUDutcyg==}
+  /core-js/3.24.0:
+    resolution: {integrity: sha512-IeOyT8A6iK37Ep4kZDD423mpi6JfPRoPUdQwEWYiGolvn4o6j2diaRzNfDfpTdu3a5qMbrGUzKUpYpRY8jXCkQ==}
     requiresBuild: true
     dev: true
 
@@ -9695,7 +9690,7 @@ packages:
     dependencies:
       cli-truncate: 3.1.0
       colorette: 2.0.17
-      commander: 9.3.0
+      commander: 9.4.0
       debug: 4.3.4
       execa: 6.1.0
       lilconfig: 2.0.5
@@ -10565,7 +10560,7 @@ packages:
       bl: 4.1.0
       chalk: 4.1.2
       cli-cursor: 3.1.0
-      cli-spinners: 2.7.0
+      cli-spinners: 2.6.1
       is-interactive: 1.0.0
       is-unicode-supported: 0.1.0
       log-symbols: 4.1.0


### PR DESCRIPTION
Allow for access to the original command instance via `this.command`. This is a breaking change by making the `CommandRunner` an `abstract` class so that `this.command` can properly be set.