### PR TITLE
typo(doc): add imports and fix typo in example

### DIFF
--- a/apps/docs/docs/features/commander.md
+++ b/apps/docs/docs/features/commander.md
@@ -82,12 +82,14 @@ You can also make an option completely required, like an argument, by setting `r
 
 ### Setting Choices for your Options
 
-Commander also allows us to set up pre-defined choices for options. To do so we have two options: setting the `choices` array directly as a part of the `@Option()` decorator, or using the `@OptionChoicesFor()` decorator and a class method, similar to the [InquirerService](./inquirer.md). With using the `@OptionChoicesFor()` decorator, we are also able to make use of class providers that are injected into the command via Nest's DI which allows devs to read for the choices from a file or database if that happens to be necessary.
+Commander also allows us to set up pre-defined choices for options. To do so we have two options: setting the `choices` array directly as a part of the `@Option()` decorator, or using the `@OptionChoiceFor()` decorator and a class method, similar to the [InquirerService](./inquirer.md). With using the `@OptionChoiceFor()` decorator, we are also able to make use of class providers that are injected into the command via Nest's DI which allows devs to read for the choices from a file or database if that happens to be necessary.
 
 ```typescript
+import { Option, OptionChoiceFor } from 'nest-commander'
+
 @Command({ name: 'run' })
 export class RunCommand extends CommandRunner {
-  constrtuctor(
+  constructor(
     private readonly choiceProvider: {
       getChoicesForRun: () => string[];
     }
@@ -99,16 +101,16 @@ export class RunCommand extends CommandRunner {
     console.log(options);
   }
 
-  @Options({
+  @Option({
     flags: '-c, --color [runWithColor]',
     name: 'withColor',
     description: 'Should the command use color in the output'
   })
   parseColorOption(option: string) {
-    return options;
+    return option;
   }
 
-  @OptionChoicesFor({ name: 'withColor' }) // make sure this matches the `name` of an `@Options()` decorator
+  @OptionChoiceFor({ name: 'withColor' }) // make sure this matches the `name` of an `@Options()` decorator
   getColorChoices() {
     return this.choiceProvider.getChoicesForRun();
   }


### PR DESCRIPTION
Hi

I was reading the doc, and while I was copy pasting to get a working base, I encountered those little typos :)

NB: ( not related )
I used your package in a previous project, now it's time to install it on the one I'm starting, this is really usefull
I saw it has already been updated to match nest@9, GGs !!

Have a nice day !