### PR TITLE
feat: nest-commander-scheamtics 3.0.0

### DIFF
--- a/.changeset/green-spiders-glow.md
+++ b/.changeset/green-spiders-glow.md
@@ -1,0 +1,5 @@
+---
+'nest-commander-testing': patch
+---
+
+Add 3.0.0 to peer deps

--- a/.changeset/smart-keys-cheat.md
+++ b/.changeset/smart-keys-cheat.md
@@ -1,0 +1,5 @@
+---
+'nest-commander-schematics': major
+---
+
+Schematics now create command that extends the CommandRunner abstract class

--- a/packages/nest-commander-schematics/src/command/files/with-questions/__name@dasherize__.command.ts.template
+++ b/packages/nest-commander-schematics/src/command/files/with-questions/__name@dasherize__.command.ts.template
@@ -1,8 +1,10 @@
 import { Command, CommandRunner, InquirerService } from 'nest-commander';
 
 @Command({ name: '<%= lowercase(name) %>', options: { isDefault: <%= (isDefault) %> } })
-export class <%= classify(name) %>Command implements CommandRunner {
-  constructor(private readonly inquirerService: InquirerService) {}
+export class <%= classify(name) %>Command extends CommandRunner {
+  constructor(private readonly inquirerService: InquirerService) {
+    super()
+  }
 
   async run(inputs: string[], options?: Record<string, any>) {
     options = await this.inquirerService.prompt('<%= (question) %>', options);

--- a/packages/nest-commander-schematics/src/command/files/without-questions/__name@dasherize__.command.ts.template
+++ b/packages/nest-commander-schematics/src/command/files/without-questions/__name@dasherize__.command.ts.template
@@ -1,7 +1,7 @@
 import { Command, CommandRunner } from 'nest-commander';
 
 @Command({ name: '<%= lowercase(name) %>', options: { isDefault: <%= (isDefault) %> } })
-export class <%= classify(name) %>Command implements CommandRunner {
+export class <%= classify(name) %>Command extends CommandRunner {
   async run(inputs: string[], options: Record<string, any>) {
     console.log({ inputs, options });
   }

--- a/workspace.json
+++ b/workspace.json
@@ -74,16 +74,6 @@
       "type": "library",
       "targets": {
         "build": {
-          "executor": "@nrwl/workspace:run-commands",
-          "options": {
-            "commands": [
-              "./node_modules/.bin/nx package nest-commander-schematics",
-              "tools/schematics-postbuild"
-            ],
-            "parallel": false
-          }
-        },
-        "package": {
           "executor": "@nrwl/js:tsc",
           "options": {
             "deleteOutputPath": true,
@@ -91,7 +81,10 @@
             "outputPath": "dist/nest-commander-schematics",
             "packageJson": "packages/nest-commander-schematics/package.json",
             "tsConfig": "packages/nest-commander-schematics/tsconfig.build.json",
-            "assets": ["packages/nest-commander-schematics/*.md"]
+            "assets": [
+              "packages/nest-commander-schematics/*.md",
+              "packages/nest-commander-schematics/src/**/*.json"
+            ]
           }
         },
         "publish": {


### PR DESCRIPTION
Update the schematic to use the new `extends CommandRunner` from ``nest-commander@3.0.0`

Publish a new patch for nest-commander-testing to include nest-commander 3.0.0 as a peer dep