### PR TITLE
feat: add env property to option decorator

### DIFF
--- a/.changeset/wise-buses-smoke.md
+++ b/.changeset/wise-buses-smoke.md
@@ -1,0 +1,5 @@
+---
+'nest-commander': minor
+---
+
+Add `env` option to `@Option()` decorator

--- a/packages/nest-commander/src/command-runner.interface.ts
+++ b/packages/nest-commander/src/command-runner.interface.ts
@@ -49,6 +49,7 @@ export interface OptionMetadata {
   required?: boolean;
   name?: string;
   choices?: string[] | true;
+  env?: string;
 }
 
 export interface OptionChoiceForMetadata {

--- a/packages/nest-commander/src/command-runner.service.ts
+++ b/packages/nest-commander/src/command-runner.service.ts
@@ -97,6 +97,7 @@ ${cliPluginError(this.options.cliName ?? 'nest-commander', this.options.pluginsA
         required = false,
         choices = [],
         name: optionName = '',
+        env = undefined,
       } = option.meta;
       const handler = option.discoveredMethod.handler.bind(command.instance);
       const commandOption = new Option(flags, description)
@@ -121,6 +122,9 @@ ${cliPluginError(this.options.cliName ?? 'nest-commander', this.options.pluginsA
           optionChoices = choices;
         }
         commandOption.choices(optionChoices);
+      }
+      if (env) {
+        commandOption.env(env);
       }
       commandOption.argParser(handler);
       newCommand.addOption(commandOption);


### PR DESCRIPTION
With the `env` option, the option value can come from `process.env`, as this
is already supported by `commander`.

fix: #598