### PR TITLE
fix: importing of ESM plugins (previously only worked with CommonJS)

### DIFF
--- a/.changeset/witty-spiders-cheat.md
+++ b/.changeset/witty-spiders-cheat.md
@@ -1,0 +1,5 @@
+---
+'nest-commander': patch
+---
+
+Fixed an issue preventing use of ESM packages as plugins in the command factory

--- a/packages/nest-commander/src/command.factory.ts
+++ b/packages/nest-commander/src/command.factory.ts
@@ -105,8 +105,7 @@ export class CommandFactory {
       return false;
     }
     for (const pluginPath of pluginConfig?.config.plugins ?? []) {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const plugin = require(require.resolve(pluginPath, { paths: [process.cwd()] }));
+      const plugin = await import(require.resolve(pluginPath, { paths: [process.cwd()] }));
       imports?.push(plugin.default);
     }
     return true;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13923457/199847187-d9274227-3dc9-449c-9947-dd360016335b.png)

Before this change I am unable to import modules that have been created w/ ESM (`"type": "module"` in their `package.json` and built with ES2015+ as a target), this change will allow this dynamic importing to work for ESM as well as CommonJS modules.