### PR TITLE
Bugfix/module resolution

### DIFF
--- a/.changeset/lemon-knives-move.md
+++ b/.changeset/lemon-knives-move.md
@@ -1,5 +1,5 @@
 ---
-'nest-commander': patch
+'nest-commander': minor
 ---
 
 fix: update module resolution to node16 so dynamic imports are not transpiled out during TS build

--- a/.changeset/lemon-knives-move.md
+++ b/.changeset/lemon-knives-move.md
@@ -1,0 +1,5 @@
+---
+'nest-commander': patch
+---
+
+fix: update module resolution to node16 so dynamic imports are not transpiled out during TS build

--- a/packages/nest-commander/tsconfig.build.json
+++ b/packages/nest-commander/tsconfig.build.json
@@ -1,4 +1,7 @@
 {
   "extends": "./../../tsconfig.build.json",
-  "include": ["src"]
+  "include": ["src"],
+  "compilerOptions": {
+    "moduleResolution": "Node16"
+  }
 }


### PR DESCRIPTION
So the dynamic import adjustments I made earlier today in PR #626 didn't 100% take due to an oversight of mine.

Due to the default moduleResolution setting in TypeScript, the dynamic `import()` statement I added to support ESM ended up being completely transpiled out of the built JavaScript file.

This module resolution update fixes that, here's the difference in the compiled code:

```diff
- const plugin = await Promise.resolve().then(() => require(require.resolve(pluginPath, { paths: [process.cwd()] })));
+ const plugin = await import(require.resolve(pluginPath, { paths: [process.cwd()] }));
```

Here's the [TypeScript Docs Site Reference for module resolution](https://www.typescriptlang.org/docs/handbook/module-resolution.html) if you're curious at all