### PR TITLE
docs(): update nest-commander logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![CI](https://github.com/jmcdo29/nest-commander/workflows/CI/badge.svg) [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/) [![Coffee](https://badgen.net/badge/Buy%20Me/A%20Coffee/purple?icon=kofi)](https://www.buymeacoffee.com/jmcdo29) [![codebeat badge](https://codebeat.co/badges/886435cf-0ace-403b-8f9c-3e4eb99fbd5d)](https://codebeat.co/projects/github-com-jmcdo29-nest-commander-main)
   
   <p align="center">
-    <a href="https://jmcdo29.github.io/nest-commander" target="blank"><img src="apps/docs/static/img/nest-commander-final.svg" width="120" alt="Nest Commander Logo" /></a>
+    <a href="https://jmcdo29.github.io/nest-commander" target="blank"><img src="https://nest-commander.jaymcdoniel.dev/img/nest-commander-final.svg" width="220" alt="Nest Commander Logo" /></a>
   </p>
 </div>
 


### PR DESCRIPTION
The logo in the readme is not displayed (see screenshot):

<img width="837" alt="Schermata 2022-11-18 alle 21 20 04" src="https://user-images.githubusercontent.com/11542387/202845191-de1d7506-d4bc-48c5-bc6c-d75412639746.png">
