### PR TITLE
Add a way to get the app instance

### DIFF
--- a/packages/nest-commander/src/command.factory.ts
+++ b/packages/nest-commander/src/command.factory.ts
@@ -16,8 +16,10 @@ export class CommandFactory {
   static async run(
     rootModule: Type<any>,
     optionsOrLogger?: CommandFactoryRunOptions | NestLogger,
+    getterCallback?: (app: INestApplicationContext) => void,
   ): Promise<void> {
     const app = await this.runApplication(rootModule, optionsOrLogger);
+    if (getterCallback) getterCallback(app);
     await app.close();
   }
 


### PR DESCRIPTION
In my app I make extensive use of the app instance that I can get anywhere because the NestFactory returns an instance. The use case is DB models and similar classes that aren't part of the dependency injection directly. But the CommandFactory does not return the instance, and I understand why - nothing can be `return`ed until the command is done running. So I figured we could do it with a callback instead.