### PR TITLE
feat: allow for positional options

### DIFF
--- a/.changeset/six-geckos-travel.md
+++ b/.changeset/six-geckos-travel.md
@@ -1,0 +1,5 @@
+---
+'nest-commander': minor
+---
+
+Allow for options to be parsed positionally via an option passed to CommandFactory

--- a/apps/docs/src/pages/en/api.md
+++ b/apps/docs/src/pages/en/api.md
@@ -227,6 +227,7 @@ Options that can be passed to the `run` or `runWithoutClosing` method to modify 
 | errorHandler | `Function` | false | A custom error handler that takes in an `Error` and returns `void` synchronously. |
 | usePlugins | `boolean` | false | The choice of if the built CLI should look for a config file and plugins or not. |
 | cliName | `string` | false | The name of the CLI and the prefix for the config file to be looked for. Defaults to `"nest-commander"`. |
+| enablePositionalOptions | `boolean` | false | Make commander view `<comamnd> -p <sub-command>` and `<command <sub-command> -p` as two different commands. [Commander's reference](https://github.com/tj/commander.js#parsing-configuration) |
 
 ## nest-commander-testing
 

--- a/packages/nest-commander/src/command-factory.interface.ts
+++ b/packages/nest-commander/src/command-factory.interface.ts
@@ -20,4 +20,5 @@ export interface CommanderOptionsType {
   usePlugins?: boolean;
   cliName?: string;
   pluginsAvailable?: boolean;
+  enablePositionalOptions?: boolean;
 }

--- a/packages/nest-commander/src/command-runner.service.ts
+++ b/packages/nest-commander/src/command-runner.service.ts
@@ -45,6 +45,9 @@ ${cliPluginError(this.options.cliName ?? 'nest-commander', this.options.pluginsA
     if (this.options.errorHandler) {
       this.commander.exitOverride(this.options.errorHandler);
     }
+    if (this.options.enablePositionalOptions) {
+      this.commander.enablePositionalOptions();
+    }
   }
 
   private async populateCommandMapInstances(


### PR DESCRIPTION
Adds a new options to the `CommandFactory.run()` so that the same option in a command and sub-command can be parsed separately. With this option enabled the two commands will be read differently by commander

```
say -m hello yellow
say yellow -m hello
```

The former will have `hello` go to the `say` command while the latter will have `hello` go to the `yellow` sub-command of `say`

Closes #663 