### PR TITLE
feat: allow for a sub command to be the default

### DIFF
--- a/.changeset/dry-months-return.md
+++ b/.changeset/dry-months-return.md
@@ -1,0 +1,5 @@
+---
+'nest-commander': minor
+---
+
+Allow for a sub command to be set as the default sub command.

--- a/apps/docs/src/pages/en/features/commander.md
+++ b/apps/docs/src/pages/en/features/commander.md
@@ -176,6 +176,8 @@ After adding the subcommand to the appropriate module's `providers` array, nest-
 
 Subcommands can also take an `aliases` array for sub command aliases. We could add `aliases: ['f']` to the above `FooCommand` and run it with `my-exec f` instead of `my-exec foo` and get the same result. `aliases` must be passed as an array.
 
+You can also use the `options: { isDefault: true }` option of the`@SubCommand()` decorator to set a default subcommand for the command.
+
 ## The Full Command
 
 Let's say all we want to do is have our `my-exec` command run the task in another shell, and that's it. If we take our above command we can see that it can be ran like so

--- a/integration/default-sub-commands/src/bottom.command.ts
+++ b/integration/default-sub-commands/src/bottom.command.ts
@@ -1,0 +1,14 @@
+import { CommandRunner, SubCommand } from 'nest-commander';
+
+import { LogService } from '../../common/log.service';
+
+@SubCommand({ name: 'bottom', options: { isDefault: true } })
+export class BottomCommand extends CommandRunner {
+  constructor(private readonly log: LogService) {
+    super();
+  }
+
+  async run() {
+    this.log.log('top mid-1 bottom command');
+  }
+}

--- a/integration/default-sub-commands/src/mid-1.command.ts
+++ b/integration/default-sub-commands/src/mid-1.command.ts
@@ -1,0 +1,15 @@
+import { CommandRunner, SubCommand } from 'nest-commander';
+
+import { LogService } from '../../common/log.service';
+import { BottomCommand } from './bottom.command';
+
+@SubCommand({ name: 'mid-1', subCommands: [BottomCommand], options: { isDefault: true } })
+export class Mid1Command extends CommandRunner {
+  constructor(private readonly log: LogService) {
+    super();
+  }
+
+  async run() {
+    this.log.log('top mid-1 command');
+  }
+}

--- a/integration/default-sub-commands/src/mid-2.command.ts
+++ b/integration/default-sub-commands/src/mid-2.command.ts
@@ -1,0 +1,14 @@
+import { CommandRunner, SubCommand } from 'nest-commander';
+
+import { LogService } from '../../common/log.service';
+
+@SubCommand({ name: 'mid-2', aliases: ['m'] })
+export class Mid2Command extends CommandRunner {
+  constructor(private readonly log: LogService) {
+    super();
+  }
+
+  async run() {
+    this.log.log('top mid-2 command');
+  }
+}

--- a/integration/default-sub-commands/src/nested.module.ts
+++ b/integration/default-sub-commands/src/nested.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+
+import { LogService } from '../../common/log.service';
+import { BottomCommand } from './bottom.command';
+import { Mid1Command } from './mid-1.command';
+import { Mid2Command } from './mid-2.command';
+import { TopCommand } from './top.command';
+
+@Module({
+  providers: [LogService, TopCommand, Mid1Command, Mid2Command, BottomCommand],
+})
+export class NestedModule {}

--- a/integration/default-sub-commands/src/top.command.ts
+++ b/integration/default-sub-commands/src/top.command.ts
@@ -1,0 +1,17 @@
+import { Command, CommandRunner } from 'nest-commander';
+
+import { LogService } from '../../common/log.service';
+import { Mid1Command } from './mid-1.command';
+import { Mid2Command } from './mid-2.command';
+
+@Command({ name: 'top', arguments: '[name]', subCommands: [Mid1Command, Mid2Command] })
+export class TopCommand extends CommandRunner {
+  constructor(private readonly log: LogService) {
+    super();
+  }
+
+  async run(inputs: string[]) {
+    this.log.log('top command');
+    this.log.log(inputs);
+  }
+}

--- a/integration/default-sub-commands/test/default-sub-commands.spec.ts
+++ b/integration/default-sub-commands/test/default-sub-commands.spec.ts
@@ -1,0 +1,43 @@
+import { TestingModule } from '@nestjs/testing';
+import { Stub, stubMethod } from 'hanbi';
+import { CommandTestFactory } from 'nest-commander-testing';
+import { suite } from 'uvu';
+import { equal } from 'uvu/assert';
+import { LogService } from '../../common/log.service';
+import { NestedModule } from '../src/nested.module';
+
+export const DefaultSubCommandSuite = suite<{
+  logMock: Stub<typeof console.log>;
+  exitMock: Stub<typeof process.exit>;
+  commandInstance: TestingModule;
+}>('Default Sub Command Suite');
+DefaultSubCommandSuite.before(async (context) => {
+  context.exitMock = stubMethod(process, 'exit');
+  context.logMock = stubMethod(console, 'log');
+  context.commandInstance = await CommandTestFactory.createTestingCommand({
+    imports: [NestedModule],
+  })
+    .overrideProvider(LogService)
+    .useValue({
+      log: context.logMock.handler,
+    })
+    .compile();
+});
+DefaultSubCommandSuite.after.each(({ logMock, exitMock }) => {
+  logMock.reset();
+  exitMock.reset();
+});
+DefaultSubCommandSuite.after(({ exitMock }) => {
+  exitMock.restore();
+});
+DefaultSubCommandSuite('top should call top mid1 bottom', async ({ commandInstance, logMock }) => {
+  await CommandTestFactory.run(commandInstance, ['top']);
+  equal(logMock.firstCall?.args[0], `top mid-1 bottom command`);
+});
+DefaultSubCommandSuite(
+  'top mid-2 should call top mid2 command',
+  async ({ commandInstance, logMock }) => {
+    await CommandTestFactory.run(commandInstance, ['top', 'mid-2']);
+    equal(logMock.firstCall?.args[0], `top mid-2 command`);
+  },
+);

--- a/integration/index.spec.ts
+++ b/integration/index.spec.ts
@@ -5,6 +5,7 @@ import {
   StringCommandSuite,
   UnknownCommandSuite,
 } from './basic/test/basic.command.spec';
+import { DefaultSubCommandSuite } from './default-sub-commands/test/default-sub-commands.spec';
 import { DotCommandSuite } from './dot-command/test/dot.command.spec';
 import { HelpSuite } from './help-tests/test/help.spec';
 import { MultipleCommandSuite } from './multiple/test/multiple.command.spec';
@@ -33,3 +34,4 @@ SetQuestionSuite.run();
 OptionChoiceSuite.run();
 DotCommandSuite.run();
 RegisterWithSubCommandsSuite.run();
+DefaultSubCommandSuite.run();

--- a/packages/nest-commander/src/command-runner.service.ts
+++ b/packages/nest-commander/src/command-runner.service.ts
@@ -45,9 +45,6 @@ ${cliPluginError(this.options.cliName ?? 'nest-commander', this.options.pluginsA
     if (this.options.errorHandler) {
       this.commander.exitOverride(this.options.errorHandler);
     }
-    if (this.options.enablePositionalOptions) {
-      this.commander.enablePositionalOptions();
-    }
   }
 
   private async populateCommandMapInstances(

--- a/packages/nest-commander/src/command-runner.service.ts
+++ b/packages/nest-commander/src/command-runner.service.ts
@@ -150,7 +150,9 @@ ${cliPluginError(this.options.cliName ?? 'nest-commander', this.options.pluginsA
       );
       const subCommands = await this.populateCommandMapInstances(subCommandsMetaForCommand);
       for (const subCommand of subCommands) {
-        newCommand.addCommand(await this.buildCommand(subCommand));
+        newCommand.addCommand(await this.buildCommand(subCommand), {
+          isDefault: subCommand.command.options?.isDefault ?? false,
+        });
       }
     }
     return newCommand;


### PR DESCRIPTION
By adding `options: { isDefault: true }` to a `@SubCommand()` the sub command will be considered the default sub command and activated if `<command>` is called without any extra subcommands

Ref #663