### PR TITLE
feat: runWithoutClosing for testing

### DIFF
--- a/.changeset/gentle-lemons-explain.md
+++ b/.changeset/gentle-lemons-explain.md
@@ -1,0 +1,5 @@
+---
+'nest-commander-testing': minor
+---
+
+Add runWithoutClosing for testing

--- a/packages/nest-commander-testing/src/command-test.factory.ts
+++ b/packages/nest-commander-testing/src/command-test.factory.ts
@@ -67,13 +67,22 @@ export class CommandTestFactory {
   }
 
   static async run(app: TestingModule, args: string[] = []) {
+    const application = await this.runApplication(app, args);
+    await application.close();
+  }
+
+  static async runWithoutClosing(app: TestingModule, args: string[] = []) {
+    return this.runApplication(app, args);
+  }
+
+  private static async runApplication(app: TestingModule, args: string[] = []) {
     if (args?.length && args[0] !== 'node') {
       args = ['node', randomBytes(8).toString('hex') + '.js'].concat(args);
     }
     await app.init();
     const runner = app.get(CommandRunnerService);
     await runner.run(args);
-    await app.close();
+    return app;
   }
 
   static setAnswers(value: any | any[]): void {


### PR DESCRIPTION
Hello,

i would like to use the `runWithoutClosing` method for e2e test too.

My cronjob creates a report in the database. After the command ran, i would like to query the database and check the result. 

This is not possible with the `run` method. The application closes.

With `runWithoutClosing` i can query the databse, check the result and close the application after the ckeck.


Example: 
```ts
// imports ...

describe("Cronjob User Count (e2e)", () => {
  let commandInstance: TestingModule;
  let usersRepository: UsersRepository;
  let usersReportsRepository: UsersReportsRepository;

  beforeEach(async () => {
    commandInstance = await CommandTestFactory.createTestingCommand({
      imports: [AppModule],
    }).compile();

    usersRepository = commandInstance.get(UsersRepository);
    usersReportsRepository = commandInstance.get(UsersReportsRepository);

    await usersReportsRepository.delete({ id: Not(IsNull()) });
    await usersRepository.delete({ id: Not(IsNull()) });

  });

  afterEach(async () => {
    commandInstance.close();
  });

  it("Should create user count reports", async () => {
    for (let i = 0; i < 5; i++) {
      await usersRepository.save(
        usersRepository.create({
          name: `User ${i}`,
        })
      );
    }

    await CommandTestFactory.runWithoutClosing(commandInstance, ["user-count-cronjob"]);

    const reports = await usersReportsRepository.find();
    expect(reports).toHaveLength(1);
  });
});
```

Is it possible to add this feature?
Would be cool!

Thanks for your feedback!