### PR TITLE
feat: need to run Without Closing in testing package too

### DIFF
--- a/packages/nest-commander-testing/src/command-test.factory.ts
+++ b/packages/nest-commander-testing/src/command-test.factory.ts
@@ -76,6 +76,15 @@ export class CommandTestFactory {
     await app.close();
   }
 
+  static async runWithoutClosing(app: TestingModule, args: string[] = []) {
+    if (args?.length && args[0] !== 'node') {
+      args = ['node', randomBytes(8).toString('hex') + '.js'].concat(args);
+    }
+    await app.init();
+    const runner = app.get(CommandRunnerService);
+    await runner.run(args);
+  }
+
   static setAnswers(value: any | any[]): void {
     if (!Array.isArray(value)) {
       value = [value];


### PR DESCRIPTION
Hi ,

i am nestjs-backend-developer in south korea

I wish you understand that I am not good at English

nest-commander-testing Package's **run**-method has app.close();

but this closes the DB connection.   (in my E2E - test )  (CommandTestFactory.run ( ) )

In fact, the company used it as an example below.
```ts
export class CustomCommandTestFactory {
  static async runWithoutClosing(app: TestingModule, args: string[] = []) {
    if (args?.length !== 0 && args[0] !== 'node') {
      args = ['node', randomBytes(8).toString('hex') + '.js'].concat(args)
    }
    await app.init()
    const runner = app.get(CommandRunnerService)
    await runner.run(args)
  }
}
```

But, nestjs-commander has **runWithoutClosing** method.

plz) merge this.

then my company will love this library

thanku