### PR TITLE
feat(core): add new module decorator to set request

### DIFF
--- a/.changeset/chilled-jars-smile.md
+++ b/.changeset/chilled-jars-smile.md
@@ -1,0 +1,7 @@
+---
+'nest-commander': minor
+---
+
+Allow for use of request scoped providers through a new module decorator
+
+By making use of the `@RequestModule()` decorator for modules, as mock request object can be set as a singleton to help the use of `REQUEST` scoped providers in a singleton context. There's now also an error that is logged in the case of a property of `undefined` being called, as this is usually indicative of a `REQUEST` scoped provider being called from a `SINGLETON` context.

--- a/apps/docs/src/pages/en/api.md
+++ b/apps/docs/src/pages/en/api.md
@@ -248,6 +248,26 @@ export class AppModule {}
 | --- | --- | --- | --- |
 | meta | `string` | false | `@Command` or `@SubCommand` decorator identifier is explicitly specified for extracting metadata,<br/> It is used internal this library and you shouldn't need to specify it normally. |
 
+### @RequestModule()
+
+A wrapper decorator for Nest's `@Module()` that exposes a way to set a request object mock for the `REQUEST` injection token.
+
+```typescript
+@RequestModule({
+  providers: [SomeCommand],
+  requestObject: { headers: { Authorization: 'Bearer token' } }
+})
+export class SomeCommandModule {}
+```
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| imports | Array<ModuleImport> | false | Imports for the current module. This is Nest's standard property |
+| controllers | Type<any>[] | false | Controllers for the module |
+| providers | Provider[] | false | Providers for the module. This includes commands |
+| exports | Array<ModuleImport or Provider> | false | Values the module exports |
+| requestObject | Object | false | The mock request object that should be used in place of `REQUEST` |
+
 ## nest-commander-testing
 
 ### CommandTestFactory

--- a/apps/docs/src/pages/en/features/commander.md
+++ b/apps/docs/src/pages/en/features/commander.md
@@ -178,6 +178,20 @@ Subcommands can also take an `aliases` array for sub command aliases. We could a
 
 You can also use the `options: { isDefault: true }` option of the`@SubCommand()` decorator to set a default subcommand for the command.
 
+## Request Scoped Commands
+
+In a CLI environment requests don't exist in the traditional HTTP sense. Because of this, `REQUEST` scoped providers are problematic inside of `nest-commander` commands. However, thanks to the `@RequestModule()` decorator it is possible to create a mock value for the command to make use of so that the command and all of its dependencies remain `SINGLETON` or `DEFAULT` scoped allowing the original providers of the application to be used without a major bit of re-architecting. The decorator works _just_ like `@Module()` with one extra field, `requestObject` that gets merged into the `providers` array under the `REQUEST` provider token from `@nestjs/core`. This makes Nest resolve the "proper" value for `REQUEST` because it exists inside the current module.
+
+```ts
+@RequestModule({
+  providers: [SimpleCommand, RequestScopedProvider],
+  requestObject: { headers: { Authorization: 'Bearer token' } }
+})
+export class RequestScopedCommandModule {}
+```
+
+While we _call_ it `RequestScoped`, it is very much set to be singleton, which is a win for re-using existing providers.
+
 ## The Full Command
 
 Let's say all we want to do is have our `my-exec` command run the task in another shell, and that's it. If we take our above command we can see that it can be ran like so

--- a/integration/index.spec.ts
+++ b/integration/index.spec.ts
@@ -17,6 +17,7 @@ import { ThisCommandHandlerSuite } from './this-command/test/this-command.comman
 import { ThisOptionHandlerSuite } from './this-handler/test/this-handler.command.spec';
 import { SetQuestionSuite } from './with-questions/test/hello.command.spec';
 import { RegisterWithSubCommandsSuite } from './register-provider/test/register-with-subcommands.spec';
+import { RequestProviderSuite } from './request-provider-override/test/index.spec';
 
 BasicFactorySuite.run();
 StringCommandSuite.run();
@@ -35,3 +36,4 @@ OptionChoiceSuite.run();
 DotCommandSuite.run();
 RegisterWithSubCommandsSuite.run();
 DefaultSubCommandSuite.run();
+RequestProviderSuite.run();

--- a/integration/request-provider-override/src/request-provider.module.ts
+++ b/integration/request-provider-override/src/request-provider.module.ts
@@ -1,0 +1,10 @@
+import { RequestModule } from 'nest-commander';
+import { LogService } from '../../common/log.service';
+import { RequestScopedService } from './request-scoped.service';
+import { SimpleCommand } from './simple.command';
+
+@RequestModule({
+  providers: [LogService, SimpleCommand, RequestScopedService],
+  requestObject: { custom: 'value' },
+})
+export class RequestProviderModule {}

--- a/integration/request-provider-override/src/request-scoped.service.ts
+++ b/integration/request-provider-override/src/request-scoped.service.ts
@@ -1,0 +1,13 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+
+@Injectable()
+export class RequestScopedService {
+  constructor(@Inject(REQUEST) private readonly req: Record<string, string>) {
+    console.log(this.req);
+  }
+
+  getRequest() {
+    return this.req;
+  }
+}

--- a/integration/request-provider-override/src/simple.command.ts
+++ b/integration/request-provider-override/src/simple.command.ts
@@ -1,0 +1,17 @@
+import { Command, CommandRunner } from 'nest-commander';
+import { LogService } from '../../common/log.service';
+import { RequestScopedService } from './request-scoped.service';
+
+@Command({ name: 'simple', options: { isDefault: true } })
+export class SimpleCommand extends CommandRunner {
+  constructor(
+    private readonly requestProvider: RequestScopedService,
+    private readonly logger: LogService,
+  ) {
+    super();
+  }
+
+  async run(_params: Record<string, any>, _options: Record<string, any>) {
+    this.logger.log(this.requestProvider.getRequest());
+  }
+}

--- a/integration/request-provider-override/test/index.spec.ts
+++ b/integration/request-provider-override/test/index.spec.ts
@@ -1,6 +1,4 @@
-import { Logger } from '@nestjs/common';
 import { stubMethod } from 'hanbi';
-import { CommandFactory } from 'nest-commander';
 import { CommandTestFactory } from 'nest-commander-testing';
 import { suite } from 'uvu';
 import { equal } from 'uvu/assert';

--- a/integration/request-provider-override/test/index.spec.ts
+++ b/integration/request-provider-override/test/index.spec.ts
@@ -1,0 +1,22 @@
+import { Logger } from '@nestjs/common';
+import { stubMethod } from 'hanbi';
+import { CommandFactory } from 'nest-commander';
+import { CommandTestFactory } from 'nest-commander-testing';
+import { suite } from 'uvu';
+import { equal } from 'uvu/assert';
+import { LogService } from '../../common/log.service';
+import { RequestProviderModule } from '../src/request-provider.module';
+
+export const RequestProviderSuite = suite('Default Request Provider');
+
+RequestProviderSuite('Default Request Provider', async () => {
+  const logSpy = stubMethod(console, 'log');
+  const commandInstance = await CommandTestFactory.createTestingCommand({
+    imports: [RequestProviderModule],
+  })
+    .overrideProvider(LogService)
+    .useValue({ log: logSpy.handler })
+    .compile();
+  await CommandTestFactory.run(commandInstance, []);
+  equal(logSpy.firstCall?.args[0], { custom: 'value' });
+});

--- a/packages/nest-commander/src/command-runner.module.ts
+++ b/packages/nest-commander/src/command-runner.module.ts
@@ -1,4 +1,4 @@
-import { DynamicModule, Module, Type } from '@nestjs/common';
+import { DynamicModule, Logger, Module, Type } from '@nestjs/common';
 import { DiscoveryModule } from '@golevelup/nestjs-discovery';
 import { Command } from 'commander';
 import * as inquirer from 'inquirer';
@@ -23,6 +23,7 @@ export class CommandRunnerModule {
       module: CommandRunnerModule,
       imports: module ? [module, DiscoveryModule] : [DiscoveryModule],
       providers: [
+        Logger,
         CommandRunnerService,
         InquirerService,
         {

--- a/packages/nest-commander/src/command-runner.service.ts
+++ b/packages/nest-commander/src/command-runner.service.ts
@@ -146,6 +146,7 @@ ${cliPluginError(this.options.cliName ?? 'nest-commander', this.options.pluginsA
             '',
             'CommandRunnerService',
           );
+          return;
         } else {
           throw err;
         }

--- a/packages/nest-commander/src/index.ts
+++ b/packages/nest-commander/src/index.ts
@@ -6,3 +6,4 @@ export * from './command-runner.module';
 export * from './command-runner.service';
 export { Inquirer } from './constants';
 export * from './inquirer.service';
+export * from './request-module.decorator';

--- a/packages/nest-commander/src/request-module.decorator.ts
+++ b/packages/nest-commander/src/request-module.decorator.ts
@@ -1,0 +1,14 @@
+import { Module, ModuleMetadata } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+
+export const RequestModule = (
+  metadata: ModuleMetadata & { requestObject: Record<string, any> },
+): ClassDecorator => {
+  const { requestObject, ...moduleMetadata } = metadata;
+  moduleMetadata.providers ??= [];
+  moduleMetadata.providers.push({
+    provide: REQUEST,
+    useValue: requestObject,
+  });
+  return Module(moduleMetadata);
+};


### PR DESCRIPTION
The addition of the `@RequestModule()` decorator allows for users to
override the standard `REQUEST` object that Nest provides. This is so
users can use request scoped providers without having to re-architect
their entire application and instead can just provide a mock object.

ref: #754