### PR TITLE
feat: add in a service error handler option

### DIFF
--- a/.changeset/forty-rockets-beg.md
+++ b/.changeset/forty-rockets-beg.md
@@ -1,0 +1,9 @@
+---
+'nest-commander': minor
+---
+
+Add serviceErrorHandler option
+
+This option allows for catching and handling errors at the Nest service execution level so that
+lifecycle hooks still properly work. By default it is set to
+`(err: Error) => process.stderr.write(err.toString())`.

--- a/apps/docs/src/pages/en/api.md
+++ b/apps/docs/src/pages/en/api.md
@@ -258,6 +258,7 @@ Options that can be passed to the `run` or `runWithoutClosing` method to modify 
 | usePlugins              | `boolean`    | false    | The choice of if the built CLI should look for a config file and plugins or not.                                                                                                              |
 | cliName                 | `string`     | false    | The name of the CLI and the prefix for the config file to be looked for. Defaults to `"nest-commander"`.                                                                                      |
 | enablePositionalOptions | `boolean`    | false    | Make commander view `<comamnd> -p <sub-command>` and `<command <sub-command> -p` as two different commands. [Commander's reference](https://github.com/tj/commander.js#parsing-configuration) |
+| serviceErrorHandler     | `Function`   | false    | A custom error handler that takes in an `Error` and return `void`. This is to handle errors at the Nest service level rather than the command level like `errorHandler`                       |
 
 ### CommandRunner
 

--- a/packages/nest-commander/src/command-factory.interface.ts
+++ b/packages/nest-commander/src/command-factory.interface.ts
@@ -13,12 +13,10 @@ export interface CommandFactoryRunOptions {
   errorHandler?: ErrorHandler;
   usePlugins?: boolean;
   cliName?: string;
+  serviceErrorHandler?: ErrorHandler;
 }
 
-export interface CommanderOptionsType {
-  errorHandler?: ErrorHandler;
-  usePlugins?: boolean;
-  cliName?: string;
+export interface CommanderOptionsType extends Omit<CommandFactoryRunOptions, 'logger'> {
   pluginsAvailable?: boolean;
   enablePositionalOptions?: boolean;
 }

--- a/packages/nest-commander/src/command-runner.service.ts
+++ b/packages/nest-commander/src/command-runner.service.ts
@@ -46,6 +46,9 @@ ${cliPluginError(this.options.cliName ?? 'nest-commander', this.options.pluginsA
     if (this.options.errorHandler) {
       this.commander.exitOverride(this.options.errorHandler);
     }
+    if (!this.options.serviceErrorHandler) {
+      this.options.serviceErrorHandler = (err: Error) => process.stderr.write(err.toString());
+    }
   }
 
   private async populateCommandMapInstances(
@@ -190,6 +193,6 @@ ${cliPluginError(this.options.cliName ?? 'nest-commander', this.options.pluginsA
   }
 
   async run(args?: string[]): Promise<void> {
-    await this.commander.parseAsync(args || process.argv);
+    await this.commander.parseAsync(args || process.argv).catch(this.options.serviceErrorHandler);
   }
 }


### PR DESCRIPTION
This option varies from the `errrorHandler` option in that it catches
errors at the Nest execution level so that the `onApplicationShutdown`
hook (and similar) can still function properly

ref #794