### PR TITLE
Bugfix service error handler option

### DIFF
--- a/.changeset/wicked-pants-lie.md
+++ b/.changeset/wicked-pants-lie.md
@@ -1,0 +1,5 @@
+---
+'nest-commander': patch
+---
+
+Fixed issue with parsing serviceErrorHandler option to properly override default behaviour

--- a/packages/nest-commander/src/command.factory.ts
+++ b/packages/nest-commander/src/command.factory.ts
@@ -62,17 +62,19 @@ export class CommandFactory {
     let tempHandler: ((err: Error) => void) | undefined;
     let usePlugins = false;
     let cliName = 'nest-commander';
+    let serviceErrorHandler = undefined;
     if (this.isFactoryOptionsObject(optionsOrLogger)) {
       ({
         logger,
         errorHandler: tempHandler,
         cliName = cliName,
         usePlugins = usePlugins,
+        serviceErrorHandler,
       } = optionsOrLogger);
     } else {
       logger = optionsOrLogger;
     }
-    return { logger, errorHandler: tempHandler, usePlugins, cliName };
+    return { logger, errorHandler: tempHandler, usePlugins, cliName, serviceErrorHandler };
   }
 
   private static isFactoryOptionsObject(


### PR DESCRIPTION
This PR fixes issue with loading the `serviceErrorHandler` option so that it can really override the default behaviour when supplied.