### PR TITLE
Feat add output configuration

### DIFF
--- a/.changeset/tidy-poets-turn.md
+++ b/.changeset/tidy-poets-turn.md
@@ -1,5 +1,6 @@
 ---
 'nest-commander': minor
+'nest-commander-testing': minor
 ---
 
 Add ability to set outputConfiguration.

--- a/.changeset/tidy-poets-turn.md
+++ b/.changeset/tidy-poets-turn.md
@@ -1,0 +1,8 @@
+---
+'nest-commander': minor
+---
+
+Add ability to set outputConfiguration.
+
+Now CommandFactory.run(), CommandFactory.runWithoutClosing() and
+CommandFactory.createWithoutRunning() accept the option `outputConfiguration`.

--- a/integration/index.spec.ts
+++ b/integration/index.spec.ts
@@ -19,6 +19,7 @@ import { SetQuestionSuite } from './with-questions/test/hello.command.spec';
 import { RegisterWithSubCommandsSuite } from './register-provider/test/register-with-subcommands.spec';
 import { RequestProviderSuite } from './request-provider-override/test/index.spec';
 import { RootCommandSuite } from './root-command/test/root-command.spec';
+import { OutputConfigSuite } from './output-config/test/output.config.spec';
 
 BasicFactorySuite.run();
 StringCommandSuite.run();
@@ -39,3 +40,4 @@ RegisterWithSubCommandsSuite.run();
 DefaultSubCommandSuite.run();
 RequestProviderSuite.run();
 RootCommandSuite.run();
+OutputConfigSuite.run();

--- a/integration/output-config/src/basic.command.ts
+++ b/integration/output-config/src/basic.command.ts
@@ -1,0 +1,21 @@
+import { Command, CommandRunner, Option } from 'nest-commander';
+
+@Command({ name: 'basic' })
+export class BasicCommand extends CommandRunner {
+  constructor() {
+    super();
+  }
+
+  async run(): Promise<void> {
+    // no op
+  }
+
+  @Option({
+    flags: '-n, --number <number>',
+    description: 'A basic number option',
+    required: true,
+  })
+  parseNumber(val: string): number {
+    return Number(val);
+  }
+}

--- a/integration/output-config/src/root.module.ts
+++ b/integration/output-config/src/root.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { BasicCommand } from './basic.command';
+
+@Module({
+  providers: [BasicCommand],
+})
+export class RootModule {}

--- a/integration/output-config/test/output.config.spec.ts
+++ b/integration/output-config/test/output.config.spec.ts
@@ -1,0 +1,61 @@
+import { TestingModule } from '@nestjs/testing';
+import { CommandTestFactory } from 'nest-commander-testing';
+import { spy, Stub, stubMethod } from 'hanbi';
+import { suite } from 'uvu';
+import { equal } from 'uvu/assert';
+import { LogService } from '../../common/log.service';
+import { RootModule } from '../src/root.module';
+
+export const OutputConfigSuite = suite<{
+  commandInstance: TestingModule;
+  errorLogMock: Stub<Console['log']>;
+}>('OutputConfig Test suite');
+
+OutputConfigSuite.before(async (context) => {
+  context.errorLogMock = spy();
+  context.commandInstance = await CommandTestFactory.createTestingCommand(
+    {
+      imports: [RootModule],
+    },
+    {
+      outputConfiguration: {
+        writeErr: (msg) => context.errorLogMock.handler(msg),
+      },
+      serviceErrorHandler: (err) => {
+        throw err;
+      },
+    },
+  ).compile();
+});
+
+OutputConfigSuite.after.each(({ errorLogMock }) => {
+  errorLogMock.reset();
+});
+
+OutputConfigSuite(
+  'outputConfig should be use in the root command',
+  async ({ commandInstance, errorLogMock }) => {
+    const exitSpy = stubMethod(process, 'exit');
+    // unknown command, should trigger an error
+    await CommandTestFactory.run(commandInstance, ['unknown']);
+    equal(
+      errorLogMock.firstCall?.args[0],
+      `error: unknown command 'unknown'\n`,
+    );
+    exitSpy.restore();
+  },
+);
+
+OutputConfigSuite(
+  'outputConfig should have been passed down to subcommands',
+  async ({ commandInstance, errorLogMock }) => {
+    const exitSpy = stubMethod(process, 'exit');
+    // no args given, should trigger an error
+    await CommandTestFactory.run(commandInstance, ['basic']);
+    equal(
+      errorLogMock.firstCall?.args[0],
+      `error: required option '-n, --number <number>' not specified\n`,
+    );
+    exitSpy.restore();
+  },
+);

--- a/integration/output-config/test/output.config.spec.ts
+++ b/integration/output-config/test/output.config.spec.ts
@@ -3,7 +3,6 @@ import { CommandTestFactory } from 'nest-commander-testing';
 import { spy, Stub, stubMethod } from 'hanbi';
 import { suite } from 'uvu';
 import { equal } from 'uvu/assert';
-import { LogService } from '../../common/log.service';
 import { RootModule } from '../src/root.module';
 
 export const OutputConfigSuite = suite<{

--- a/packages/nest-commander-testing/src/command-test.factory.ts
+++ b/packages/nest-commander-testing/src/command-test.factory.ts
@@ -7,7 +7,7 @@ import {
   CommandRunnerService,
   Inquirer,
 } from 'nest-commander';
-import { CommanderOptionsType } from 'packages/nest-commander/src/command-factory.interface';
+import { CommanderOptionsType } from 'nest-commander';
 
 export type CommandModuleMetadata = Exclude<ModuleMetadata, 'imports'> & {
   imports: NonNullable<ModuleMetadata['imports']>;

--- a/packages/nest-commander-testing/src/command-test.factory.ts
+++ b/packages/nest-commander-testing/src/command-test.factory.ts
@@ -7,6 +7,7 @@ import {
   CommandRunnerService,
   Inquirer,
 } from 'nest-commander';
+import { CommanderOptionsType } from 'packages/nest-commander/src/command-factory.interface';
 
 export type CommandModuleMetadata = Exclude<ModuleMetadata, 'imports'> & {
   imports: NonNullable<ModuleMetadata['imports']>;
@@ -22,8 +23,11 @@ export class CommandTestFactory {
   }
   static createTestingCommand(
     moduleMetadata: CommandModuleMetadata,
+    options?: CommanderOptionsType,
   ): TestingModuleBuilder {
-    moduleMetadata.imports.push(CommandRunnerModule.forModule());
+    moduleMetadata.imports.push(
+      CommandRunnerModule.forModule(undefined, options),
+    );
     const testingModule = Test.createTestingModule(moduleMetadata);
     if (!this.useOriginalInquirer) {
       testingModule.overrideProvider(Inquirer).useValue({

--- a/packages/nest-commander/src/command-factory.interface.ts
+++ b/packages/nest-commander/src/command-factory.interface.ts
@@ -1,5 +1,6 @@
 import { LoggerService, LogLevel } from '@nestjs/common';
 import { NestApplicationContextOptions } from '@nestjs/common/interfaces/nest-application-context-options.interface';
+import { OutputConfiguration } from 'commander';
 
 export type ErrorHandler = (err: Error) => void;
 export type NestLogger = LoggerService | LogLevel[] | false;
@@ -19,6 +20,7 @@ export interface CommandFactoryRunOptions
   serviceErrorHandler?: ErrorHandler;
   enablePositionalOptions?: boolean;
   enablePassThroughOptions?: boolean;
+  outputConfiguration?: OutputConfiguration;
 }
 
 export interface CommanderOptionsType

--- a/packages/nest-commander/src/command-runner.service.ts
+++ b/packages/nest-commander/src/command-runner.service.ts
@@ -61,6 +61,9 @@ ${cliPluginError(
       this.options.serviceErrorHandler = (err: Error) =>
         process.stderr.write(err.toString());
     }
+    if (this.options.outputConfiguration) {
+      this.commander.configureOutput(this.options.outputConfiguration);
+    }
   }
 
   /**
@@ -124,6 +127,9 @@ ${cliPluginError(
   private async buildCommand(command: RunnerMeta): Promise<Command> {
     const newCommand = new Command(command.command.name);
     command.instance.setCommand(newCommand);
+    if (this.options.outputConfiguration) {
+      newCommand.configureOutput(this.options.outputConfiguration);
+    }
     if (command.command.arguments) {
       this.mapArgumentDescriptions(
         newCommand,

--- a/packages/nest-commander/src/command.factory.ts
+++ b/packages/nest-commander/src/command.factory.ts
@@ -90,6 +90,7 @@ export class CommandFactory {
     options.enablePositionalOptions = options.enablePositionalOptions || false;
     options.enablePassThroughOptions =
       options.enablePassThroughOptions || false;
+    options.outputConfiguration = options.outputConfiguration || undefined;
 
     return options as DefinedCommandFactoryRunOptions;
   }

--- a/packages/nest-commander/src/index.ts
+++ b/packages/nest-commander/src/index.ts
@@ -5,5 +5,6 @@ export * from './command-runner.interface';
 export * from './command-runner.module';
 export * from './command-runner.service';
 export { Inquirer } from './constants';
+export { CommanderOptionsType } from './command-factory.interface';
 export * from './inquirer.service';
 export * from './request-module.decorator';


### PR DESCRIPTION
Hey ! 

I have been using nest-commander for a project and needed to override the commander error response (unknown command, options error, etc.) to use my logger instead. However, it seems that nest-commander does not provide an interface that allows access to the outputConfiguration.

Therefore, I attempted to bypass the interface by doing the following:

```ts
async function bootstrap() {
  const app = await CommandFactory.createWithoutRunning(CommandsModule, {
    logger: new Logger(),
  });

  /* eslint-disable @typescript-eslint/ban-ts-comment */
  /* eslint-disable n/handle-callback-err */
  const m = app.get(CommandRunnerService);
  // @ts-expect-error
  const cmd = m.commander as Command; // force to get a private property
  cmd.configureOutput({
    writeErr: (str: string): void => {
      console.error(str);
    },
    writeOut: (str: string): void => {
      console.log(str);
    },
  });

  await CommandFactory.runApplication(app);

  await app.close();
}
```
However, this is not a good coding practice. Additionally, the previous code does not set the outputConfiguration for the subcommands. To address this, I added the following:

```ts
export abstract class CommandRunnerWithNestLogger extends CommandRunner {
  protected readonly logger: Logger;

  constructor(className: string) {
    super();
    this.logger = new Logger(className);
  }

  public setCommand(command: Command): this {
    this.command = command;
    this.command.configureOutput({
      writeErr: (str: string) => {
        this.logger.error(str);
      },
      writeOut: (str: string) => {
        this.logger.log(str);
      },
    });
    return this;
  }
}
```

To handle this issue, I made a small change in the nest-commander code that allows setting the outputConfiguration in the Command Factory and propagating it to the subcommands. This enables us to do the following:
```ts
const bootstrap = async () => {
  await CommandFactory.run(RootModule, {
    outputConfiguration: {
      writeErr: (message) => this.myLogger.error(message),
    },
  });
};
```

This is my first time contributing to an open-source project, so please let me know if there are any changes or additions I should make.

Thanks!

PS : I also wanted to add the ability to change the  outputConfiguration directly from a **CommandRunner** to add more flexibility, similar to what I did in my second code. However, I didn't do it yet, pending your feedback.