### PR TITLE
Add global version option

### DIFF
--- a/.changeset/polite-socks-develop.md
+++ b/.changeset/polite-socks-develop.md
@@ -1,0 +1,5 @@
+---
+'nest-commander': minor
+---
+
+Add The possibility to set the global version option

--- a/apps/docs/src/pages/en/api.md
+++ b/apps/docs/src/pages/en/api.md
@@ -273,6 +273,7 @@ Options that can be passed to the `run` or `runWithoutClosing` method to modify 
 | cliName                 | `string`     | false    | The name of the CLI and the prefix for the config file to be looked for. Defaults to `"nest-commander"`.                                                                                      |
 | enablePositionalOptions | `boolean`    | false    | Make commander view `<comamnd> -p <sub-command>` and `<command <sub-command> -p` as two different commands. [Commander's reference](https://github.com/tj/commander.js#parsing-configuration) |
 | serviceErrorHandler     | `Function`   | false    | A custom error handler that takes in an `Error` and return `void`. This is to handle errors at the Nest service level rather than the command level like `errorHandler`                       |
+| version                 | `string`     | false    | The global version of the CLI. If this option is set, the -V or --version option will be enabled.                                                                                             |
 
 ### CommandRunner
 

--- a/integration/index.spec.ts
+++ b/integration/index.spec.ts
@@ -20,6 +20,7 @@ import { RegisterWithSubCommandsSuite } from './register-provider/test/register-
 import { RequestProviderSuite } from './request-provider-override/test/index.spec';
 import { RootCommandSuite } from './root-command/test/root-command.spec';
 import { OutputConfigSuite } from './output-config/test/output.config.spec';
+import { VersionOptionSuite } from './version-option/test/version.option.spec';
 
 BasicFactorySuite.run();
 StringCommandSuite.run();
@@ -41,3 +42,4 @@ DefaultSubCommandSuite.run();
 RequestProviderSuite.run();
 RootCommandSuite.run();
 OutputConfigSuite.run();
+VersionOptionSuite.run();

--- a/integration/version-option/src/root.module.ts
+++ b/integration/version-option/src/root.module.ts
@@ -1,0 +1,6 @@
+import { Module } from '@nestjs/common';
+
+@Module({
+  providers: [],
+})
+export class RootModule {}

--- a/integration/version-option/test/version.option.spec.ts
+++ b/integration/version-option/test/version.option.spec.ts
@@ -1,0 +1,60 @@
+import { CommandTestFactory } from 'nest-commander-testing';
+import { stubMethod } from 'hanbi';
+import { suite } from 'uvu';
+import { equal } from 'uvu/assert';
+import { RootModule } from '../src/root.module';
+
+export const VersionOptionSuite = suite('Version option');
+
+VersionOptionSuite('Running version, and version enabled', async () => {
+  const version = '1.0.0';
+  const commandInstance = await CommandTestFactory.createTestingCommand(
+    {
+      imports: [RootModule],
+    },
+    {
+      version,
+    },
+  ).compile();
+  let stdoutSpy = stubMethod(process.stdout, 'write');
+  const exitSpy = stubMethod(process, 'exit');
+
+  await CommandTestFactory.run(commandInstance, ['--version']);
+  let stdOutResult = stdoutSpy.firstCall?.args[0] as string;
+  equal(stdOutResult.includes(version), true);
+
+  stdoutSpy.restore();
+  stdoutSpy = stubMethod(process.stdout, 'write');
+
+  await CommandTestFactory.run(commandInstance, ['-V']);
+  stdOutResult = stdoutSpy.firstCall?.args[0] as string;
+  equal(stdOutResult.includes(version), true);
+
+  stdoutSpy.restore();
+  exitSpy.restore();
+});
+
+VersionOptionSuite(
+  'Running version, but version option is disabled',
+  async () => {
+    const commandInstance = await CommandTestFactory.createTestingCommand(
+      {
+        imports: [RootModule],
+      },
+      {
+        // no version option
+      },
+    ).compile();
+
+    const stderrSpy = stubMethod(process.stderr, 'write');
+    const exitSpy = stubMethod(process, 'exit');
+
+    await CommandTestFactory.run(commandInstance, ['--version']);
+
+    // error: unknown option '--version'
+    equal(stderrSpy.firstCall?.args[0], `error: unknown option '--version'\n`);
+
+    exitSpy.restore();
+    stderrSpy.restore();
+  },
+);

--- a/packages/nest-commander/src/command-factory.interface.ts
+++ b/packages/nest-commander/src/command-factory.interface.ts
@@ -21,6 +21,7 @@ export interface CommandFactoryRunOptions
   enablePositionalOptions?: boolean;
   enablePassThroughOptions?: boolean;
   outputConfiguration?: OutputConfiguration;
+  version?: string;
 }
 
 export interface CommanderOptionsType

--- a/packages/nest-commander/src/command-runner.service.ts
+++ b/packages/nest-commander/src/command-runner.service.ts
@@ -64,6 +64,10 @@ ${cliPluginError(
     if (this.options.outputConfiguration) {
       this.commander.configureOutput(this.options.outputConfiguration);
     }
+
+    if (this.options.version) {
+      this.commander.version(this.options.version);
+    }
   }
 
   /**


### PR DESCRIPTION
Hey again @jmcdo29  ;) !
I made a really small change. I wanted to include the current version of my API in a cli option.
So I added the version option at the factory level :
```ts
  const app = await CommandFactory.createWithoutRunning(CommandsModule, {
    version: getVersion() ?? 'UNKNOWN'
  });
```
Do you think it deserves to be merged?
Thank