### PR TITLE
fix: re-throw error regardless if it is a reading undefined error

### DIFF
--- a/.changeset/happy-rules-work.md
+++ b/.changeset/happy-rules-work.md
@@ -1,0 +1,6 @@
+---
+'nest-commander': patch
+---
+
+The CommandRunnerService now re-throws the error regardless of the contents, it
+just adds a new log above the error as well

--- a/packages/nest-commander/src/command-runner.service.ts
+++ b/packages/nest-commander/src/command-runner.service.ts
@@ -212,13 +212,9 @@ ${cliPluginError(
               err.stack,
               'CommandRunnerService',
             );
-            return;
-          } else {
-            throw err;
           }
-        } else {
-          throw err;
         }
+        throw err;
       }
     });
     if (command.command.subCommands?.length) {


### PR DESCRIPTION
Due to the need to call the custom error handler when it is passed
it makes more sense to generally just re-throw the existing error
if one occurs. So now, there will be a logged message about possibly
using a request scoped service and the error will be fully handled
by the error handler.

ref: #1039