### PR TITLE
fix: use the name passed to the options decorator for the name passed to the command

### DIFF
--- a/.changeset/kind-turkeys-type.md
+++ b/.changeset/kind-turkeys-type.md
@@ -1,0 +1,5 @@
+---
+'nest-commander': patch
+---
+
+Remap the options to the name passed in the `@Options()` decorator, if provided

--- a/integration/option-choices/src/option-choices.command.ts
+++ b/integration/option-choices/src/option-choices.command.ts
@@ -16,7 +16,7 @@ export class OptionsTestCommand extends CommandRunner {
   ) {
     super();
   }
-  async run(_args: never[], options: { choice: string }) {
+  async run(_args: never[], options: { choices: string }) {
     this.logger.log(options);
   }
 

--- a/integration/option-choices/test/option-choices.spec.ts
+++ b/integration/option-choices/test/option-choices.spec.ts
@@ -26,14 +26,14 @@ OptionChoiceSuite(
   'Send in option "yes"',
   async ({ commandInstance, logMock }) => {
     await CommandTestFactory.run(commandInstance, ['-c', 'yes']);
-    equal(logMock.firstCall?.args[0], { choice: 'yes' });
+    equal(logMock.firstCall?.args[0], { choices: 'yes' });
   },
 );
 OptionChoiceSuite(
   'Send in option "no"',
   async ({ commandInstance, logMock }) => {
     await CommandTestFactory.run(commandInstance, ['-c', 'no']);
-    equal(logMock.firstCall?.args[0], { choice: 'no' });
+    equal(logMock.firstCall?.args[0], { choices: 'no' });
   },
 );
 OptionChoiceSuite(

--- a/packages/nest-commander/src/command-runner.service.ts
+++ b/packages/nest-commander/src/command-runner.service.ts
@@ -152,6 +152,8 @@ ${cliPluginError(
       newCommand.passThroughOptions(true);
     }
 
+    const optionNameMap: Record<string, string> = {};
+
     for (const option of command.params) {
       const {
         flags,
@@ -191,6 +193,7 @@ ${cliPluginError(
       }
       commandOption.argParser(handler);
       newCommand.addOption(commandOption);
+      optionNameMap[commandOption.name()] = optionName || commandOption.name();
     }
     for (const help of command.help ?? []) {
       newCommand.addHelpText(
@@ -202,7 +205,12 @@ ${cliPluginError(
     newCommand.action(async () => {
       try {
         command.instance.run.bind(command.instance);
-        return await command.instance.run(newCommand.args, newCommand.opts());
+        const passedOptions = newCommand.opts();
+        const trueOptions: Record<string, string> = {};
+        for (const opt in passedOptions) {
+          trueOptions[optionNameMap[opt]] = passedOptions[opt];
+        }
+        return await command.instance.run(newCommand.args, trueOptions);
       } catch (err) {
         if (err instanceof Error) {
           if (err.message.includes('Cannot read properties of undefined')) {


### PR DESCRIPTION
There was already a test for this, that I didn't realize was initially incorrect, so I was able to verify this does indeed work as expected

fix: #1070 