### PR TITLE
Fix typo: "fale" to "false"

### DIFF
--- a/apps/docs/src/pages/en/schematics/usage.md
+++ b/apps/docs/src/pages/en/schematics/usage.md
@@ -56,6 +56,6 @@ The available options for this command are the following:
 --name=<name>         Questions set name.
 --path=<name>         The path to create the service.
 --sourceRoot=<name>   NestJS service source root directory.
---flat                Whether or not a directory is created. (default: fale)
+--flat                Whether or not a directory is created. (default: false)
 --spec                Whether or not a spec file is generated. (default: true)
 ```


### PR DESCRIPTION
Correct fale to false 😆