### PR TITLE
feat: add optional support for filesystem autocompletion

### DIFF
--- a/.changeset/ten-rivers-fold.md
+++ b/.changeset/ten-rivers-fold.md
@@ -1,0 +1,6 @@
+---
+'nest-commander': minor
+---
+
+Enhance filesystem autocomplete support for Bash and Zsh by introducing an
+opt-in option based on an environment variable.

--- a/packages/nest-commander/src/constants.ts
+++ b/packages/nest-commander/src/constants.ts
@@ -46,6 +46,16 @@ _{{app_name}}_nest_commander_completions()
     cur_word="\${COMP_WORDS[COMP_CWORD]}"
     args=("\${COMP_WORDS[@]}")
 
+    # Check if {{app_name}}_nest_commander_filesystem_completions is set to "true" or "1"
+    # If it is, use filename completion if last word starts with common filesystem operator chars
+    #  \`.\` , \`/\` or \`~\` e.g. \`./\`, \`../\`, \`/\`, \`~/\` 
+    if [[ "\${{{app_name}}_nest_commander_filesystem_completions}" == "true" ]] || [[ "\${{{app_name}}_nest_commander_filesystem_completions}" == "1" ]]; then
+        if [[ "\${cur_word}" =~ ^\\.  ]] || [[ "\${cur_word}" =~ ^/ ]] || [[ "\${cur_word}" =~ ^~ ]]; then
+            COMPREPLY=($(compgen -f -- "\${cur_word}"))
+            return 0
+        fi
+    fi
+
     # ask nest commander to generate completions.
     type_list=$({{app_path}} completion "\${args[@]}")
 
@@ -74,8 +84,26 @@ _{{app_name}}_nest_commander_completions()
 {
   local reply
   local si=$IFS
+
+  # Check if {{app_name}}_nest_commander_filesystem_completions is set to "true" or "1"
+  # If it is, use zsh filename completion if last word starts with common filesystem operator chars
+  #  \`.\` , \`/\` or \`~\` e.g. \`./\`, \`../\`, \`/\`, \`~/\` 
+  if [[ "\${{{app_name}}_nest_commander_filesystem_completions}" == "true" ]] || [[ "\${{{app_name}}_nest_commander_filesystem_completions}" == "1" ]]; then
+    if [[ "\${words[-1]}" =~ ^\\.  ]] || [[ "\${words[-1]}" =~ ^/ ]] || [[ "\${words[-1]}" =~ ^~ ]]; then
+      _path_files
+      return
+    fi
+  fi
+
   IFS=$'\n' reply=($(COMP_CWORD="$((CURRENT-1))" COMP_LINE="$BUFFER" COMP_POINT="$CURSOR" {{app_path}} completion "\${words[@]}"))
   IFS=$si
+
+  # if no match was found, fall back to filename completion
+  if [[ -z "\${reply[*]}" ]]; then
+    _path_files
+    return
+  fi
+
   _describe 'values' reply
 }
 compdef _{{app_name}}_nest_commander_completions {{app_name}}


### PR DESCRIPTION
This pull request includes changes to the `packages/nest-commander/src/constants.ts` file. The changes introduce a new feature to the `_{{app_name}}_nest_commander_completions()` function that allows filename completion when the last word starts with common filesystem operator characters such as `.`, `/`, or `~`. This feature is enabled when the `{{app_name}}_nest_commander_filesystem_completions` variable is set to "true" or "1". Additionally, a fallback to filename completion has been added for zsh when no match is found.

Here are the key changes:

* [`packages/nest-commander/src/constants.ts`](diffhunk://#diff-830f743ddff716c79c2812e2da71412bd098f7afff83589c05012db0db72fc54R49-R58): Added a condition to check if `{{app_name}}_nest_commander_filesystem_completions` is set to "true" or "1". If so, filename completion is used if the last word starts with `.`, `/`, or `~`.
* [`packages/nest-commander/src/constants.ts`](diffhunk://#diff-830f743ddff716c79c2812e2da71412bd098f7afff83589c05012db0db72fc54R87-R106): Similar to the previous change, but for zsh filename completion. Also added a fallback to filename completion if no match was found.