### PR TITLE
Add option for Help Configuration

### DIFF
--- a/.changeset/twelve-rabbits-nail.md
+++ b/.changeset/twelve-rabbits-nail.md
@@ -1,0 +1,6 @@
+---
+'nest-commander': minor
+---
+
+feat: Add option for Help Configuration using the .configureHelp() function in
+commander js

--- a/packages/nest-commander/src/command-factory.interface.ts
+++ b/packages/nest-commander/src/command-factory.interface.ts
@@ -1,6 +1,6 @@
 import { LoggerService, LogLevel } from '@nestjs/common';
 import { NestApplicationContextOptions } from '@nestjs/common/interfaces/nest-application-context-options.interface';
-import { OutputConfiguration } from 'commander';
+import { Help, OutputConfiguration } from 'commander';
 import type { CompletionFactoryOptions } from './completion.factory.interface';
 
 export type ErrorHandler = (err: Error) => void;
@@ -22,6 +22,7 @@ export interface CommandFactoryRunOptions
   enablePositionalOptions?: boolean;
   enablePassThroughOptions?: boolean;
   outputConfiguration?: OutputConfiguration;
+  helpConfiguration?: Help;
   version?: string;
 
   /**

--- a/packages/nest-commander/src/command-runner.service.ts
+++ b/packages/nest-commander/src/command-runner.service.ts
@@ -54,6 +54,9 @@ ${cliPluginError(
   this.options.pluginsAvailable,
 )}`);
     }
+    if (this.options.helpConfiguration) {
+      this.commander.configureHelp(this.options.helpConfiguration);
+    }
     if (this.options.errorHandler) {
       this.commander.exitOverride(this.options.errorHandler);
     }
@@ -133,6 +136,9 @@ ${cliPluginError(
     command.instance.setCommand(newCommand);
     if (this.options.outputConfiguration) {
       newCommand.configureOutput(this.options.outputConfiguration);
+    }
+    if (this.options.helpConfiguration) {
+      newCommand.configureHelp(this.options.helpConfiguration);
     }
     if (command.command.arguments) {
       this.mapArgumentDescriptions(

--- a/packages/nest-commander/src/command.factory.ts
+++ b/packages/nest-commander/src/command.factory.ts
@@ -98,6 +98,7 @@ export class CommandFactory {
       options.enablePassThroughOptions || false;
     options.outputConfiguration = options.outputConfiguration || undefined;
     options.completion = options.completion || false;
+    options.helpConfiguration = options.helpConfiguration || undefined;
 
     return options as DefinedCommandFactoryRunOptions;
   }


### PR DESCRIPTION
Add option for Help Configuration using the `.configureHelp()` function in commander js

https://github.com/tj/commander.js/tree/v11.1.0?tab=readme-ov-file#more-configuration-2