### PR TITLE
feat: re-throw error in default serviceErrorHandler

### DIFF
--- a/packages/nest-commander/src/command-runner.service.ts
+++ b/packages/nest-commander/src/command-runner.service.ts
@@ -61,8 +61,10 @@ ${cliPluginError(
       this.commander.exitOverride(this.options.errorHandler);
     }
     if (!this.options.serviceErrorHandler) {
-      this.options.serviceErrorHandler = (err: Error) =>
+      this.options.serviceErrorHandler = async (err: Error) => {
         process.stderr.write(err.toString());
+        throw err;
+      };
     }
     if (this.options.outputConfiguration) {
       this.commander.configureOutput(this.options.outputConfiguration);


### PR DESCRIPTION
This makes errors bubble up to `await CommandFactory.run(...);` like they should.

Example code utilizing new behavior:

```typescript
import { CommandFactory } from 'nest-commander';
import { CommanderModule } from './commander.module';

async function bootstrap() {
  try {
    await CommandFactory.run(CommanderModule, ['verbose', 'debug', 'log', 'warn', 'error']);
  } catch (e) {
    console.error(e);
    process.exit(1);
  }
}

bootstrap();
```