### PR TITLE
Ensure app is closed using try/finally

### DIFF
--- a/packages/nest-commander/src/command.factory.ts
+++ b/packages/nest-commander/src/command.factory.ts
@@ -19,8 +19,11 @@ export class CommandFactory {
     optionsOrLogger?: CommandFactoryRunOptions | NestLogger,
   ): Promise<void> {
     const app = await this.createWithoutRunning(rootModule, optionsOrLogger);
-    await this.runApplication(app);
-    await app.close();
+    try {
+      await this.runApplication(app);
+    } finally {
+      await app.close();
+    }
   }
 
   static async runWithoutClosing(


### PR DESCRIPTION
When calling `CommandFactory.run()`, ensure that the app is closed by wrapping it in a try/finally clause.