### PR TITLE
Update api reference link from '../api' to '../api.md'

### DIFF
--- a/apps/docs/src/pages/en/features/inquirer.md
+++ b/apps/docs/src/pages/en/features/inquirer.md
@@ -113,5 +113,5 @@ access `inquirer` directly using `this.inquirerService.inquirer`.
 
 :::
 
-Visit the [api docs](../api) to learn more about the `InquirerService`'s `ask` command and extra
+Visit the [api docs](../api.md) to learn more about the `InquirerService`'s `ask` command and extra
 decorators.

--- a/apps/docs/src/pages/en/features/inquirer.md
+++ b/apps/docs/src/pages/en/features/inquirer.md
@@ -113,5 +113,5 @@ access `inquirer` directly using `this.inquirerService.inquirer`.
 
 :::
 
-Visit the [api docs](../api.md) to learn more about the `InquirerService`'s `ask` command and extra
+Visit the [api docs](../../api) to learn more about the `InquirerService`'s `ask` command and extra
 decorators.


### PR DESCRIPTION
This pull request includes a small change to the `apps/docs/src/pages/en/features/inquirer.md` file. The change corrects the link to the API documentation for the `InquirerService`'s `ask` command.

Documentation update:

* [`apps/docs/src/pages/en/features/inquirer.md`](diffhunk://#diff-688de577abd7fdeb941fb1dd7244c34a78eeba8caad62eddedcd1137a8dd7b31L116-R116): Corrected the link to the API documentation from `../api` to `../api.md`.