### PR TITLE
feat: turn Help partial for helpConfiguration option

### DIFF
--- a/packages/nest-commander/src/command-factory.interface.ts
+++ b/packages/nest-commander/src/command-factory.interface.ts
@@ -23,7 +23,7 @@ export interface CommandFactoryRunOptions
   enablePositionalOptions?: boolean;
   enablePassThroughOptions?: boolean;
   outputConfiguration?: OutputConfiguration;
-  helpConfiguration?: Help;
+  helpConfiguration?: Partial<Help>;
   version?: string;
 
   /**


### PR DESCRIPTION
Simple PR to make `Help` partial in `helpConfiguration` option since Commander don't requires all methods in `.configureHelp`