### PR TITLE
chore: upgrade @golevelup/nestjs-discovery from 4.0.3 to 5.0.0

### DIFF
--- a/.changeset/friendly-ears-scream.md
+++ b/.changeset/friendly-ears-scream.md
@@ -1,0 +1,5 @@
+---
+'nest-commander': minor
+---
+
+Bump @golevelup/nestjs-discovery from v4 to v5 (for real this time)

--- a/packages/nest-commander/package.json
+++ b/packages/nest-commander/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://nest-commander.jaymcdoniel.dev",
   "dependencies": {
     "@fig/complete-commander": "^3.0.0",
-    "@golevelup/nestjs-discovery": "4.0.3",
+    "@golevelup/nestjs-discovery": "5.0.0",
     "commander": "11.1.0",
     "cosmiconfig": "8.3.6",
     "inquirer": "8.2.7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,8 +196,8 @@ importers:
         specifier: ^3.0.0
         version: 3.2.0(commander@11.1.0)
       '@golevelup/nestjs-discovery':
-        specifier: 4.0.3
-        version: 4.0.3(@nestjs/common@11.0.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.4(@nestjs/common@11.0.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))
+        specifier: 5.0.0
+        version: 5.0.0(@nestjs/common@11.0.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.4(@nestjs/common@11.0.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))
       '@nestjs/common':
         specifier: ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
         version: 11.0.6(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -1425,12 +1425,6 @@ packages:
     peerDependencies:
       '@nestjs/common': ^10.x
       '@nestjs/core': ^10.x
-
-  '@golevelup/nestjs-discovery@4.0.3':
-    resolution: {integrity: sha512-8w3CsXHN7+7Sn2i419Eal1Iw/kOjAd6Kb55M/ZqKBBwACCMn4WiEuzssC71LpBMI1090CiDxuelfPRwwIrQK+A==}
-    peerDependencies:
-      '@nestjs/common': ^10.x || ^11.0.0
-      '@nestjs/core': ^10.x || ^11.0.0
 
   '@golevelup/nestjs-discovery@5.0.0':
     resolution: {integrity: sha512-NaIWLCLI+XvneUK05LH2idHLmLNITYT88YnpOuUQmllKtiJNIS3woSt7QXrMZ5k3qUWuZpehEVz1JtlX4I1KyA==}
@@ -7643,16 +7637,16 @@ snapshots:
       '@nestjs/core': 10.4.4(@nestjs/common@11.0.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
       lodash: 4.17.21
 
-  '@golevelup/nestjs-discovery@4.0.3(@nestjs/common@11.0.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.4(@nestjs/common@11.0.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))':
-    dependencies:
-      '@nestjs/common': 11.0.6(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 10.4.4(@nestjs/common@11.0.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      lodash: 4.17.21
-
   '@golevelup/nestjs-discovery@5.0.0(@nestjs/common@11.0.16(file-type@20.5.0)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.0.6(@nestjs/common@11.0.16(file-type@20.5.0)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))':
     dependencies:
       '@nestjs/common': 11.0.16(file-type@20.5.0)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.0.6(@nestjs/common@11.0.16(file-type@20.5.0)(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      lodash: 4.17.21
+
+  '@golevelup/nestjs-discovery@5.0.0(@nestjs/common@11.0.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.4(@nestjs/common@11.0.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))':
+    dependencies:
+      '@nestjs/common': 11.0.6(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 10.4.4(@nestjs/common@11.0.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
       lodash: 4.17.21
 
   '@humanwhocodes/config-array@0.13.0':


### PR DESCRIPTION
This PR resolves #1239.

#1240 updated it in the root package dev dependencies but did not update the version in the actual package that is published.