### PR TITLE
fix: set correct relative path to packages in repository

### DIFF
--- a/.changeset/five-comics-add.md
+++ b/.changeset/five-comics-add.md
@@ -1,0 +1,6 @@
+---
+'nest-commander-testing': patch
+'nest-commander': patch
+---
+
+Fix relative directory to package in repository

--- a/packages/nest-commander-testing/package.json
+++ b/packages/nest-commander-testing/package.json
@@ -5,7 +5,7 @@
   "repository": {
     "type": "github",
     "url": "https://github.com/jmcdo29/nest-commander.git",
-    "directory": "pacakges/nest-commander-testing"
+    "directory": "packages/nest-commander-testing"
   },
   "keywords": [
     "cli",

--- a/packages/nest-commander/package.json
+++ b/packages/nest-commander/package.json
@@ -5,7 +5,7 @@
   "repository": {
     "type": "github",
     "url": "https://github.com/jmcdo29/nest-commander.git",
-    "directory": "pacakges/nest-commander"
+    "directory": "packages/nest-commander"
   },
   "keywords": [
     "cli",


### PR DESCRIPTION
Fixed typo in the relative path to packages in the repository.

Not urgent, so I'm not sure if this warrants an actual bump of versions.