### PR TITLE
feat: add @Options<T[]> decorator for variadic options

### DIFF
--- a/.changeset/add-options-decorator.md
+++ b/.changeset/add-options-decorator.md
@@ -1,0 +1,7 @@
+---
+'nest-commander': minor
+---
+
+Add new `@Options<T[]>` decorator for variadic options with array defaults. When
+values are provided, they replace the default array instead of prepending to it.
+The existing `@Option` decorator is unchanged.

--- a/integration/index.spec.ts
+++ b/integration/index.spec.ts
@@ -20,6 +20,7 @@ import { RegisterWithSubCommandsSuite } from './register-provider/test/register-
 import { RequestProviderSuite } from './request-provider-override/test/index.spec';
 import { RootCommandSuite } from './root-command/test/root-command.spec';
 import { OutputConfigSuite } from './output-config/test/output.config.spec';
+import { VariadicOptionSuite } from './variadic-option/test/variadic-option.spec';
 import { VersionOptionSuite } from './version-option/test/version.option.spec';
 
 BasicFactorySuite.run();
@@ -42,4 +43,5 @@ DefaultSubCommandSuite.run();
 RequestProviderSuite.run();
 RootCommandSuite.run();
 OutputConfigSuite.run();
+VariadicOptionSuite.run();
 VersionOptionSuite.run();

--- a/integration/variadic-option/src/variadic-option.command.ts
+++ b/integration/variadic-option/src/variadic-option.command.ts
@@ -1,0 +1,22 @@
+import { Command, CommandRunner, Options } from 'nest-commander';
+import { LogService } from '../../common/log.service';
+
+@Command({ name: 'variadic-test', options: { isDefault: true } })
+export class VariadicOptionCommand extends CommandRunner {
+  constructor(private readonly logger: LogService) {
+    super();
+  }
+
+  async run(_args: string[], options: { locales: string[] }) {
+    this.logger.log(options);
+  }
+
+  @Options<string[]>({
+    flags: '-l, --locales [locales...]',
+    defaultValue: ['en'],
+    description: 'Locales to use',
+  })
+  parseLocale(val: string): string {
+    return val;
+  }
+}

--- a/integration/variadic-option/src/variadic-option.module.ts
+++ b/integration/variadic-option/src/variadic-option.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { LogService } from '../../common/log.service';
+import { VariadicOptionCommand } from './variadic-option.command';
+
+@Module({
+  providers: [LogService, VariadicOptionCommand],
+})
+export class VariadicOptionModule {}

--- a/integration/variadic-option/test/variadic-option.spec.ts
+++ b/integration/variadic-option/test/variadic-option.spec.ts
@@ -1,0 +1,63 @@
+import { TestingModule } from '@nestjs/testing';
+import { spy, Stub } from 'hanbi';
+import { CommandTestFactory } from 'nest-commander-testing';
+import { suite } from 'uvu';
+import { equal } from 'uvu/assert';
+import { LogService } from '../../common/log.service';
+import { VariadicOptionModule } from '../src/variadic-option.module';
+
+export const VariadicOptionSuite = suite<{
+  commandInstance: TestingModule;
+  logMock: Stub<typeof console.log>;
+}>('VariadicOption Suite');
+
+VariadicOptionSuite.before.each(async (context) => {
+  context.logMock = spy();
+  context.commandInstance = await CommandTestFactory.createTestingCommand({
+    imports: [VariadicOptionModule],
+  })
+    .overrideProvider(LogService)
+    .useValue({ log: context.logMock.handler })
+    .compile();
+});
+
+VariadicOptionSuite(
+  'Uses default value when no option is provided',
+  async ({ commandInstance, logMock }) => {
+    await CommandTestFactory.run(commandInstance);
+    equal(logMock.firstCall?.args[0], { locales: ['en'] });
+  },
+);
+
+VariadicOptionSuite(
+  'Replaces default with a single provided value',
+  async ({ commandInstance, logMock }) => {
+    await CommandTestFactory.run(commandInstance, ['-l', 'fr']);
+    equal(logMock.firstCall?.args[0], { locales: ['fr'] });
+  },
+);
+
+VariadicOptionSuite(
+  'Accumulates multiple provided values',
+  async ({ commandInstance, logMock }) => {
+    await CommandTestFactory.run(commandInstance, ['-l', 'fr', '-l', 'de']);
+    equal(logMock.firstCall?.args[0], { locales: ['fr', 'de'] });
+  },
+);
+
+VariadicOptionSuite(
+  'Accumulates three provided values without default prepended',
+  async ({ commandInstance, logMock }) => {
+    await CommandTestFactory.run(commandInstance, [
+      '-l',
+      'fr',
+      '-l',
+      'de',
+      '-l',
+      'es',
+    ]);
+    equal(logMock.firstCall?.args[0], { locales: ['fr', 'de', 'es'] });
+  },
+);
+
+VariadicOptionSuite.run();

--- a/packages/nest-commander/src/command-runner.interface.ts
+++ b/packages/nest-commander/src/command-runner.interface.ts
@@ -78,6 +78,16 @@ export interface OptionMetadata {
   env?: string;
 }
 
+export interface OptionsMetadata<T extends unknown[] = string[]> {
+  flags: string;
+  description?: string;
+  defaultValue?: T;
+  required?: boolean;
+  name?: string;
+  choices?: string[] | true;
+  env?: string;
+}
+
 export interface OptionChoiceForMetadata {
   name: string;
 }
@@ -86,6 +96,7 @@ export interface RunnerMeta {
   instance: CommandRunner;
   command: RootCommandMetadata;
   params: DiscoveredMethodWithMeta<OptionMetadata>[];
+  variadicParams: DiscoveredMethodWithMeta<OptionsMetadata>[];
   help?: DiscoveredMethodWithMeta<HelpOptions>[];
 }
 

--- a/packages/nest-commander/src/command-runner.service.ts
+++ b/packages/nest-commander/src/command-runner.service.ts
@@ -11,6 +11,7 @@ import {
   HelpOptions,
   OptionChoiceForMetadata,
   OptionMetadata,
+  OptionsMetadata,
   RootCommandMetadata,
   RunnerMeta,
 } from './command-runner.interface';
@@ -21,10 +22,24 @@ import {
   HelpMeta,
   OptionChoiceMeta,
   OptionMeta,
+  OptionsMeta,
   RootCommandMeta,
   SubCommandMeta,
 } from './constants';
 import { InjectCommander } from './command.decorators';
+
+function createVariadicArgParser(
+  handler: (value: string) => unknown,
+  defaultValue: unknown,
+): (value: string, previous: unknown) => unknown[] {
+  return (value: string, previous: unknown) => {
+    const transformed = handler(value);
+    if (previous === defaultValue || !Array.isArray(previous)) {
+      return [transformed];
+    }
+    return [...previous, transformed];
+  };
+}
 
 export class CommandRunnerService implements OnModuleInit {
   private subCommands?: DiscoveredClassWithMeta<CommandMetadata>[];
@@ -110,6 +125,11 @@ ${cliPluginError(
           OptionMeta,
           (found) => found.name === provider.discoveredClass.name,
         );
+      const variadicOptionProviders =
+        await this.discoveryService.providerMethodsWithMetaAtKey<OptionsMetadata>(
+          OptionsMeta,
+          (found) => found.name === provider.discoveredClass.name,
+        );
       const helpProviders =
         await this.discoveryService.providerMethodsWithMetaAtKey<HelpOptions>(
           HelpMeta,
@@ -119,6 +139,7 @@ ${cliPluginError(
         command: provider.meta,
         instance: provider.discoveredClass.instance as CommandRunner,
         params: optionProviders,
+        variadicParams: variadicOptionProviders,
         help: helpProviders,
       });
     }
@@ -167,47 +188,29 @@ ${cliPluginError(
 
     const optionNameMap: Record<string, string> = {};
 
+    // Process @Option params (existing behavior, unchanged)
     for (const option of command.params) {
-      const {
-        flags,
-        description,
-        defaultValue = undefined,
-        required = false,
-        choices = [],
-        name: optionName = '',
-        env = undefined,
-      } = option.meta;
       const handler = option.discoveredMethod.handler.bind(command.instance);
-      const commandOption = new Option(flags, description)
-        .default(defaultValue)
-        .preset(defaultValue)
-        .makeOptionMandatory(required);
-      // choices can be a true boolean or an array of string options for commander.
-      // If a boolean, then we know that we are expected to go find the OptionChoiceFOr method.
-      if (choices === true || (Array.isArray(choices) && choices.length)) {
-        let optionChoices = [];
-        if (choices === true) {
-          const choicesMethods =
-            await this.discoveryService.providerMethodsWithMetaAtKey<OptionChoiceForMetadata>(
-              OptionChoiceMeta,
-              (item) => item.instance === command.instance,
-            );
-          const cMethod = choicesMethods
-            .filter((choiceMethod) => choiceMethod.meta.name === optionName)
-            .map((method) => method.discoveredMethod)[0];
-          optionChoices = cMethod.handler.call(command.instance);
-        } else {
-          optionChoices = choices;
-        }
-        commandOption.choices(optionChoices);
-      }
-      if (env) {
-        commandOption.env(env);
-      }
-      commandOption.argParser(handler);
-      newCommand.addOption(commandOption);
-      optionNameMap[commandOption.attributeName()] =
-        optionName || commandOption.attributeName();
+      const commandOption = await this.configureCommandOption(
+        command,
+        newCommand,
+        option,
+        optionNameMap,
+        handler,
+      );
+      commandOption.preset(option.meta.defaultValue);
+    }
+
+    // Process @Options params (variadic with auto-accumulation)
+    for (const option of command.variadicParams) {
+      const handler = option.discoveredMethod.handler.bind(command.instance);
+      await this.configureCommandOption(
+        command,
+        newCommand,
+        option,
+        optionNameMap,
+        createVariadicArgParser(handler, option.meta.defaultValue),
+      );
     }
     for (const help of command.help ?? []) {
       newCommand.addHelpText(
@@ -259,6 +262,59 @@ ${cliPluginError(
       }
     }
     return newCommand;
+  }
+
+  private async configureCommandOption(
+    command: RunnerMeta,
+    newCommand: Command,
+    option: { meta: OptionMetadata | OptionsMetadata; discoveredMethod: any },
+    optionNameMap: Record<string, string>,
+    argParser: (value: string, previous: unknown) => unknown,
+  ): Promise<Option> {
+    const {
+      flags,
+      description,
+      defaultValue = undefined,
+      required = false,
+      choices = [],
+      name: optionName = '',
+      env = undefined,
+    } = option.meta;
+
+    const commandOption = new Option(flags, description)
+      .default(defaultValue)
+      .makeOptionMandatory(required);
+
+    // choices can be a true boolean or an array of string options for commander.
+    // If a boolean, then we know that we are expected to go find the OptionChoiceFor method.
+    if (choices === true || (Array.isArray(choices) && choices.length)) {
+      let optionChoices = [];
+      if (choices === true) {
+        const choicesMethods =
+          await this.discoveryService.providerMethodsWithMetaAtKey<OptionChoiceForMetadata>(
+            OptionChoiceMeta,
+            (item) => item.instance === command.instance,
+          );
+        const cMethod = choicesMethods
+          .filter((choiceMethod) => choiceMethod.meta.name === optionName)
+          .map((method) => method.discoveredMethod)[0];
+        optionChoices = cMethod.handler.call(command.instance);
+      } else {
+        optionChoices = choices;
+      }
+      commandOption.choices(optionChoices);
+    }
+
+    if (env) {
+      commandOption.env(env);
+    }
+
+    commandOption.argParser(argParser);
+    newCommand.addOption(commandOption);
+    optionNameMap[commandOption.attributeName()] =
+      optionName || commandOption.attributeName();
+
+    return commandOption;
   }
 
   private mapArgumentDescriptions(

--- a/packages/nest-commander/src/command.decorators.ts
+++ b/packages/nest-commander/src/command.decorators.ts
@@ -5,6 +5,7 @@ import {
   HelpOptions,
   OptionChoiceForMetadata,
   OptionMetadata,
+  OptionsMetadata,
   QuestionMetadata,
   QuestionNameMetadata,
   RootCommandMetadata,
@@ -18,6 +19,7 @@ import {
   MessageMeta,
   OptionChoiceMeta,
   OptionMeta,
+  OptionsMeta,
   QuestionMeta,
   QuestionSetMeta,
   RootCommandMeta,
@@ -70,6 +72,12 @@ export const DefaultCommand = RootCommand;
 
 export const Option = (options: OptionMetadata): MethodDecorator => {
   return applyMethodMetadata(options, OptionMeta);
+};
+
+export const Options = <T extends unknown[] = string[]>(
+  options: OptionsMetadata<T>,
+): MethodDecorator => {
+  return applyMethodMetadata(options, OptionsMeta);
 };
 
 export const OptionChoiceFor = (

--- a/packages/nest-commander/src/constants.ts
+++ b/packages/nest-commander/src/constants.ts
@@ -10,6 +10,7 @@ export const CommandMeta = metaKeyBuilder('Command:Meta');
 export const SubCommandMeta = metaKeyBuilder('Subcommand:Meta');
 export const RootCommandMeta = metaKeyBuilder('RootCommand:Meta');
 export const OptionMeta = metaKeyBuilder('Option:Meta');
+export const OptionsMeta = metaKeyBuilder('Options:Meta');
 export const OptionChoiceMeta = metaKeyBuilder('OptionChoice:Meta');
 export const QuestionSetMeta = metaKeyBuilder('QuestionSet:Meta');
 export const QuestionMeta = questionMetaBuilder('Meta');


### PR DESCRIPTION
## Summary

- Adds a new `@Options<T[]>` decorator for variadic options with array defaults
- When values are provided, they replace the default array instead of prepending to it
- Extracts shared `configureCommandOption` helper from the existing option processing loop
- The existing `@Option` decorator is completely unchanged

Fixes #847

## Test plan

- [x] Default value used when no option provided
- [x] Single value replaces the default (not prepended)
- [x] Multiple values accumulate without default leak
- [x] Three values accumulate correctly
- [x] All 69 existing + new integration tests pass
- [x] Lint and prettier pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)